### PR TITLE
communication with niimath via pipes

### DIFF
--- a/brainchop/main.py
+++ b/brainchop/main.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -7,9 +8,6 @@ from tinygrad import Tensor, dtypes
 from brainchop.niimath import (
     conform,
     bwlabel,
-    _write_nifti,
-    _run_niimath,
-    _get_temp_dir,
     niimath_dtype,
 )
 
@@ -95,10 +93,6 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
-    temp_dir = _get_temp_dir()
-    model_output = temp_dir / "model_output.nii"
-    model_output_path = Path(model_output).absolute()
-
     if args.update:
         update_models()
         return
@@ -123,7 +117,7 @@ def main():
         "... -> 1 1 ..."
     )
 
-    output_channels = model(image / image.max())
+    output_channels = model(image)
     output = (
         output_channels.argmax(axis=1)
         .rearrange("1 x y z -> z y x")
@@ -131,15 +125,14 @@ def main():
         .astype(np.uint8)
     )
 
-    _write_nifti(str(model_output_path), output, header)
-
-    bwlabel(str(model_output_path), image=output)
+    labels, new_header = bwlabel(header, output)
+    full_input = new_header + labels.tobytes()
 
     if args.export_classes:
         export_classes(output_channels, header, args.output)
         print(f"    brainchop :: Exported classes to c[channel_number]_{args.output}")
 
-    cmd = [str(model_output_path)]
+    cmd = ["niimath", "-"]
     if args.inverse_conform or args.model == "mindgrab":
         cmd += ["-reslice_nn", args.input]
 
@@ -147,18 +140,17 @@ def main():
         if args.border > 0:
             cmd += ["-close", "1", str(args.border), "0"]
         if args.mask is not None:
-            _run_niimath(cmd + ["-gz", "1", args.mask, "-odt", "char"])
+            subprocess.run(
+                cmd + ["-gz", "1", args.mask, "-odt", "char"],
+                input=full_input,
+                check=True,
+            )
         cmd += ["-mul", args.input]
     cmd += ["-gz", "1", str(args.output), "-odt", output_dtype]
 
-    _run_niimath(cmd)
+    subprocess.run(cmd, input=full_input, check=True)
 
     cleanup()
-
-    try:
-        model_output_path.unlink()  # Use pathlib's unlink
-    except OSError:
-        pass  # Handle case where file doesn't exist or can't be removed
 
 
 if __name__ == "__main__":

--- a/brainchop/niimath/__init__.py
+++ b/brainchop/niimath/__init__.py
@@ -168,7 +168,38 @@ def _write_nifti(path, data, header):
         f.write(data.tobytes())
 
 
-def conform(
+def conform(input_image_path, comply=False, ct=False):
+    """
+    Conform a NIfTI image to 256³ uint8 using niimath, returning
+    the volume (256×256×256) and the 352‑byte header.
+    """
+    inp = Path(input_image_path).absolute()
+    if not inp.exists():
+        raise FileNotFoundError(f"Input NIfTI file not found: {inp}")
+
+    comply_args = ["-comply", "256", "256", "256", "1", "1", "1", "1", "1"]
+
+    cmd = ["niimath", str(inp)]
+    if ct:
+        cmd += ["-h2c"]
+    if comply:
+        cmd += comply_args
+    cmd += ["-conform", "-gz", "0", "-", "-odt", "char"]
+
+    # run niimath, capture stdout (header+raw voxels)
+    res = subprocess.run(cmd, capture_output=True, check=True)
+    out = res.stdout
+
+    # split off header and data
+    header = out[:352]
+    data = out[352:]
+
+    # reshape into (256,256,256) uint8 volume
+    volume = np.frombuffer(data, dtype=np.uint8).reshape((256, 256, 256))
+    return volume, header
+
+
+def _conform(
     input_image_path, output_image_path="conformed.nii", comply=False, ct=False
 ):
     """
@@ -240,7 +271,25 @@ def largest_cluster(data):
     return largest_label
 
 
-def bwlabel(image_path, neighbors=26, image=None):
+def bwlabel(header: bytes, vol_data: np.ndarray, neighbors=26):
+    # fire niimath, pipe in header+data, capture its stdout
+    res = subprocess.run(
+        ["niimath", "-", "-bwlabel", str(neighbors), "-gz", "0", "-", "-odt", "char"],
+        input=header + vol_data.tobytes(),
+        capture_output=True,
+        check=True,
+    )
+    out = res.stdout
+    # split off the 352‑byte header
+    out_header, out_data = out[:352], out[352:]
+    # reinterpret and reshape into (Z,Y,X)
+    clusters = np.frombuffer(out_data, dtype=np.uint8).reshape(vol_data.shape)
+    cluster_label = largest_cluster(clusters)
+    vol_data[clusters != cluster_label] = 0
+    return vol_data, out_header
+
+
+def _bwlabel(image_path, neighbors=26, image=None):
     """
     Performs in place connected component labelling for non-zero voxels
     (conn sets neighbors: 6, 18, 26)


### PR DESCRIPTION
`niimath` supports piping in and out. This commit changes conform, bwlabel, and the final model output processing to use niimath via pipes.