### PR TITLE
skull strip option, new niimath version, version bump

### DIFF
--- a/brainchop/main.py
+++ b/brainchop/main.py
@@ -86,6 +86,12 @@ def get_parser():
         help="Crop the input for faster execution. May reduce accuracy.(defaults to percentile 2 cutoff)",
     )
     parser.add_argument(
+        "-ss",
+        "--skull_strip",
+        action="store_true",
+        help="Return just the brain compartment. An alias for -m mindgrab, that overrides -m parameter",
+    )
+    parser.add_argument(
         "-ec",
         "--export-classes",
         action="store_true",
@@ -118,8 +124,12 @@ def main():
     args.input = os.path.abspath(args.input)
     args.output = os.path.abspath(args.output)
 
-    model = get_model(args.model)
-    print(f"    brainchop :: Loaded model {args.model}")
+    modelname = args.model
+    if args.skull_strip:
+        modelname = "mindgrab"
+        args.model = modelname
+    model = get_model(modelname)
+    print(f"    brainchop :: Loaded model {modelname}")
 
     output_dtype = "char"
     # load input

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 tinygrad
-niimath>=1.0.20250529
+niimath>=1.0.20250804
 requests
 clang

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ reqs = Path("requirements.txt").read_text().splitlines()
 
 setup(
     name="brainchop",
-    version="0.1.19",
+    version="0.1.20",
     author="Mike Doan",
     author_email="spikedoanz@gmail.com",
     description="Portable and lightweight brain segmentation using tinygrad",


### PR DESCRIPTION
This PR adds a command line flag alias `--skull-stip` (`-ss`) that is a shorthand to run `mindgrab` model. So instead of the previous:
`
brainchop -m mindgrab input.nii.gz
`
we can now run
`
brainchop -ss input.nii.gz
`
Even if not always shorter, it is semantically easier