### PR TITLE
fix: make weights buffer writable for CPU backend

### DIFF
--- a/brainchop/tfjs_meshnet.py
+++ b/brainchop/tfjs_meshnet.py
@@ -25,7 +25,10 @@ class MeshNetModel:
         with open(json_path, "r") as f:
             model_spec = json.load(f)
         with open(bin_path, "rb") as f:
-            weights_data = Tensor(np.frombuffer(f.read(), dtype=np.float32))
+            # .copy() is required because np.frombuffer returns a read-only array
+            # (backed by the immutable bytes object), which causes issues when
+            # tinygrad's CPU backend tries to copy data using ctypes.from_buffer()
+            weights_data = Tensor(np.frombuffer(f.read(), dtype=np.float32).copy())
         return model_spec, weights_data
 
     def normalize(self, img: np.ndarray | Tensor, normalize_config: Dict[str, Any] | None = None) -> np.ndarray:


### PR DESCRIPTION
## Summary
- Fix `CPU=1` mode failing with `TypeError: underlying buffer is not writable`

## Root Cause

The issue is in `brainchop/tfjs_meshnet.py:28`:

```python
weights_data = Tensor(np.frombuffer(f.read(), dtype=np.float32))
```

`np.frombuffer()` returns a **read-only** numpy array because it's backed by the immutable `bytes` object returned by `f.read()`. When this array is used to create a tinygrad Tensor on the NPY device, the underlying buffer remains read-only.

When running with `CPU=1`, tinygrad needs to copy data from the NPY device to the CPU device. The copy path in `tinygrad/engine/realize.py:132` uses:

```python
dest.copyin(src.as_buffer(allow_zero_copy=True))
```

With `allow_zero_copy=True`, the NPY allocator's `_as_buffer` method returns a memoryview of the original read-only numpy array. The CPU backend's `_copyin` method then fails because it uses `ctypes.from_buffer()` which requires a writable buffer.

## The Fix

Adding `.copy()` to create a writable copy of the numpy array:

```python
weights_data = Tensor(np.frombuffer(f.read(), dtype=np.float32).copy())
```

## Test plan
- [x] Verify `CPU=1 brainchop t1_crop.nii.gz` completes successfully
- [x] Verify output file is generated correctly

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)