### PR TITLE
Add iGPU roofline profiling script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ nifti/
 *.so
 _build/
 site/
-roofline_results.json
-roofline_plot.png
+roofline_*.json
+roofline_*.png

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ nifti/
 *.so
 _build/
 site/
+roofline_results.json
+roofline_plot.png

--- a/examples/profile_roofline.py
+++ b/examples/profile_roofline.py
@@ -152,16 +152,26 @@ def profile_inference(model_name, vol, dtype, n_warmup=N_WARMUP, n_runs=N_TIMED)
 
     if dtype == "fp16":
         x = x.half()
+        # Validate that convolutions actually run in half precision.
+        # We can't check the final output because fused argmax casts to float32.
+        # Instead, probe the first conv layer directly.
+        from tinygrad import nn
+        first_conv = next(
+            (l for l in (getattr(m, 'model', None) or [])
+             if isinstance(l, nn.Conv2d)),
+            None)
+        if first_conv is not None:
+            probe = x[:, :, :4, :4, :4].conv2d(first_conv.weight, first_conv.bias,
+                                                 padding=first_conv.padding)
+            probe_dtype = probe.realize().dtype.name
+            del probe
+            if probe_dtype != "half":
+                raise RuntimeError(
+                    f"fp16 requested but conv output dtype is {probe_dtype} — "
+                    f"model does not run in true half precision")
 
-    # Warm up and validate dtype
-    out = _run_with_fuse_chunk(m, x, model_name)
-    out.numpy()
-    if dtype == "fp16" and out.dtype.name != "half":
-        raise RuntimeError(
-            f"fp16 requested but output dtype is {out.dtype.name} — "
-            f"model does not run in true half precision")
-
-    for _ in range(n_warmup - 1):
+    # Warm up (compile kernels, fill caches)
+    for _ in range(n_warmup):
         out = _run_with_fuse_chunk(m, x, model_name)
         out.numpy()  # force GPU sync
 
@@ -210,16 +220,17 @@ def _detect_gpu_name():
     return None
 
 
-def _detect_hardware(user_gflops, user_bw):
+def _detect_hardware(user_gflops, user_gflops_fp16, user_bw):
     """Return (peak_gflops_fp32, peak_gflops_fp16, peak_bw_gbs, gpu_name).
 
-    Apple Silicon does 2x throughput for fp16 vs fp32.
+    For matched Apple SKUs, fp16 peak is auto-derived as 2x fp32.
+    For unknown hardware, fp16 peak must be supplied via --peak-gflops-fp16.
     Raises SystemExit if peak specs cannot be determined.
     """
     name = _detect_gpu_name() or ""
 
     # Exact-SKU lookup: full chip name → (fp32 GFLOP/s, mem BW GB/s)
-    # Apple Silicon ALUs do 2x fp16 throughput; applied automatically below.
+    # Apple Silicon ALUs do 2x fp16 throughput; applied for matched SKUs only.
     specs = {
         "Apple M1":          (2600,   68),
         "Apple M1 Pro":      (4100,  200),
@@ -238,8 +249,8 @@ def _detect_hardware(user_gflops, user_bw):
     }
 
     gflops_fp32 = user_gflops
+    gflops_fp16 = user_gflops_fp16
     bw = user_bw
-    fp16_multiplier = 2  # Apple Silicon default; override via --peak-gflops for other HW
 
     matched_sku = None
     if name in specs:
@@ -247,16 +258,21 @@ def _detect_hardware(user_gflops, user_bw):
         g, b = specs[name]
         gflops_fp32 = gflops_fp32 or g
         bw = bw or b
+        # Apple Silicon: 2x fp16 throughput
+        gflops_fp16 = gflops_fp16 or gflops_fp32 * 2
 
     if name:
-        print(f"  Detected GPU: {name}" + (f" (matched SKU)" if matched_sku else " (unknown SKU)"))
+        print(f"  Detected GPU: {name}" + (" (matched SKU)" if matched_sku else " (unknown SKU)"))
 
     if not gflops_fp32 or not bw:
         print(f"\n  ERROR: Could not determine peak specs for '{name or 'no GPU detected'}'.")
         print("  Supply --peak-gflops and --peak-bw explicitly.")
         raise SystemExit(1)
 
-    gflops_fp16 = gflops_fp32 * fp16_multiplier
+    # fp16 peak: require explicit value for non-Apple / unknown hardware
+    if not gflops_fp16:
+        gflops_fp16 = gflops_fp32  # conservative: assume no fp16 speedup
+
     return gflops_fp32, gflops_fp16, bw, name
 
 
@@ -347,8 +363,12 @@ def main():
     parser.add_argument("--models", nargs="+", default=None)
     parser.add_argument("--dtypes", nargs="+", default=["fp32", "fp16"],
                         choices=["fp32", "fp16"])
-    parser.add_argument("--peak-gflops", type=float, default=None)
-    parser.add_argument("--peak-bw", type=float, default=None)
+    parser.add_argument("--peak-gflops", type=float, default=None,
+                        help="Peak fp32 GFLOP/s for the target device")
+    parser.add_argument("--peak-gflops-fp16", type=float, default=None,
+                        help="Peak fp16 GFLOP/s (auto-derived as 2x fp32 for Apple Silicon)")
+    parser.add_argument("--peak-bw", type=float, default=None,
+                        help="Peak memory bandwidth in GB/s")
     parser.add_argument("--runs", type=int, default=N_TIMED,
                         help=f"Number of timed inference runs (default {N_TIMED})")
     parser.add_argument("--warmup", type=int, default=N_WARMUP,
@@ -364,7 +384,8 @@ def main():
 
     registry = _load_registry()
     models = args.models or list(list_models().keys())
-    peak_fp32, peak_fp16, peak_bw, gpu_name = _detect_hardware(args.peak_gflops, args.peak_bw)
+    peak_fp32, peak_fp16, peak_bw, gpu_name = _detect_hardware(
+        args.peak_gflops, args.peak_gflops_fp16, args.peak_bw)
     slug = _hw_slug()
     backend = _get_backend()
 

--- a/examples/profile_roofline.py
+++ b/examples/profile_roofline.py
@@ -1,0 +1,752 @@
+#!/usr/bin/env python3
+"""
+iGPU profiling with roofline-style analysis for brainchop models.
+
+Measures FLOPs, memory bandwidth, and arithmetic intensity per model/dtype,
+then produces a roofline plot. Optionally wraps AMD tools (AMDuProfCLI,
+rocprof) when available.
+
+Usage:
+    # Manual roofline (works everywhere)
+    python examples/profile_roofline.py
+
+    # Specific models
+    python examples/profile_roofline.py --models tissue_fast subcortical
+
+    # FP16 only
+    python examples/profile_roofline.py --dtypes fp16
+
+    # With AMD UProf wrapper (Linux + AMD CPU)
+    python examples/profile_roofline.py --uprof
+
+    # With rocprof wrapper (Linux + ROCm GPU)
+    python examples/profile_roofline.py --rocprof
+
+    # Skip plot generation
+    python examples/profile_roofline.py --no-plot
+
+    # Custom hardware ceilings for roofline
+    python examples/profile_roofline.py --peak-gflops 500 --peak-bw 50
+
+Output:
+    examples/roofline_results.json   — raw profiling data
+    examples/roofline_plot.png       — roofline chart (requires matplotlib)
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# FLOPs / bandwidth accounting
+# ---------------------------------------------------------------------------
+
+def conv3d_flops(in_c: int, out_c: int, k: int, spatial: int,
+                 groups: int = 1, has_bias: bool = False) -> int:
+    """FLOPs for a single 3-D convolution (multiply-accumulate × 2)."""
+    # Each output element: k^3 * (in_c/groups) MACs
+    macs_per_elem = (k ** 3) * (in_c // groups)
+    total_elems = out_c * spatial
+    flops = 2 * macs_per_elem * total_elems  # mul + add
+    if has_bias:
+        flops += total_elems
+    return flops
+
+
+def conv3d_bytes(in_c: int, out_c: int, k: int, spatial: int,
+                 bytes_per_elem: int, has_bias: bool = False) -> int:
+    """Bytes transferred: input + weights + output (lower bound)."""
+    input_bytes = in_c * spatial * bytes_per_elem
+    weight_bytes = out_c * in_c * (k ** 3) * bytes_per_elem
+    if has_bias:
+        weight_bytes += out_c * bytes_per_elem
+    output_bytes = out_c * spatial * bytes_per_elem
+    return input_bytes + weight_bytes + output_bytes
+
+
+def groupnorm_flops(channels: int, spatial: int) -> int:
+    """Approximate FLOPs for GroupNorm (mean + var + normalize)."""
+    n = channels * spatial
+    return 5 * n  # mean, var, sub, div, scale
+
+
+def groupnorm_bytes(channels: int, spatial: int, bytes_per_elem: int) -> int:
+    """Bytes for GroupNorm: read input + write output."""
+    return 2 * channels * spatial * bytes_per_elem
+
+
+def activation_flops(spatial: int) -> int:
+    """FLOPs for element-wise activation (relu/gelu/silu/elu)."""
+    return spatial  # 1 op per element (approximate)
+
+
+def activation_bytes(spatial: int, bytes_per_elem: int) -> int:
+    return 2 * spatial * bytes_per_elem  # read + write
+
+
+# ---------------------------------------------------------------------------
+# Model analysis: walk the architecture and tally FLOPs / bytes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LayerProfile:
+    name: str
+    flops: int
+    bytes_transferred: int
+
+    @property
+    def arithmetic_intensity(self) -> float:
+        if self.bytes_transferred == 0:
+            return 0.0
+        return self.flops / self.bytes_transferred
+
+
+@dataclass
+class ModelProfile:
+    model_name: str
+    dtype: str
+    total_flops: int
+    total_bytes: int
+    layers: list
+    wall_time_s: float | None = None
+    achieved_gflops: float | None = None
+    achieved_bw_gbs: float | None = None
+
+    @property
+    def arithmetic_intensity(self) -> float:
+        if self.total_bytes == 0:
+            return 0.0
+        return self.total_flops / self.total_bytes
+
+
+def _bytes_per_elem(dtype: str) -> int:
+    return 2 if dtype == "fp16" else 4
+
+
+def analyze_meshnet(config_path: str, dtype: str) -> ModelProfile:
+    """Static FLOPs/bandwidth analysis of a MeshNet model."""
+    with open(config_path) as f:
+        config = json.load(f)
+
+    bpe = _bytes_per_elem(dtype)
+    spatial = 256 ** 3  # 256×256×256
+    layers_profile = []
+    total_flops = 0
+    total_bytes = 0
+    has_bias = config.get("bias", False)
+    has_bnorm = config.get("bnorm", True)
+
+    for i, layer_cfg in enumerate(config["layers"]):
+        in_c = layer_cfg["in_channels"]
+        out_c = layer_cfg["out_channels"]
+        k = layer_cfg["kernel_size"]
+
+        # Conv
+        f = conv3d_flops(in_c, out_c, k, spatial, has_bias=has_bias)
+        b = conv3d_bytes(in_c, out_c, k, spatial, bpe, has_bias=has_bias)
+        layers_profile.append(LayerProfile(f"conv_{i}", f, b))
+        total_flops += f
+        total_bytes += b
+
+        # GroupNorm (all layers except last)
+        if has_bnorm and i < len(config["layers"]) - 1:
+            gf = groupnorm_flops(out_c, spatial)
+            gb = groupnorm_bytes(out_c, spatial, bpe)
+            layers_profile.append(LayerProfile(f"gnorm_{i}", gf, gb))
+            total_flops += gf
+            total_bytes += gb
+
+        # Activation (all layers except last)
+        if i < len(config["layers"]) - 1:
+            af = activation_flops(out_c * spatial)
+            ab = activation_bytes(out_c * spatial, bpe)
+            layers_profile.append(LayerProfile(f"act_{i}", af, ab))
+            total_flops += af
+            total_bytes += ab
+
+    return ModelProfile(
+        model_name="",
+        dtype=dtype,
+        total_flops=total_flops,
+        total_bytes=total_bytes,
+        layers=[asdict(lp) for lp in layers_profile],
+    )
+
+
+def analyze_sae(n_classes: int, dtype: str) -> ModelProfile:
+    """Static FLOPs/bandwidth analysis of an SAE model.
+
+    Uses the known architecture: 5 encoder + downsample + 5 bottleneck +
+    upsample + 5 decoder + final 1×1 conv.  All convs are 3×3 with dilations
+    from DILATION_SCHEDULE, 16 channels throughout (except final).
+    """
+    from brainchop.sae_model import DILATION_SCHEDULE, LAYER_INDICES
+
+    bpe = _bytes_per_elem(dtype)
+    ch = 16  # SAE uses 16 channels throughout
+    spatial_full = 256 ** 3
+    spatial_half = 128 ** 3
+
+    layers_profile = []
+    total_flops = 0
+    total_bytes = 0
+
+    for i, idx in enumerate(LAYER_INDICES):
+        is_last = (i == len(LAYER_INDICES) - 1)
+        is_downsample = (idx == 10)
+        is_upsample = (idx == 22)
+
+        if is_last:
+            # Final 1×1 conv → n_classes
+            in_c, out_c, k = ch, n_classes, 1
+            spatial = spatial_full
+        elif is_downsample:
+            in_c, out_c, k = ch, ch, 3
+            spatial = spatial_full  # input spatial
+        elif is_upsample:
+            in_c, out_c, k = ch, ch, 2
+            spatial = spatial_half  # input spatial (output is full)
+        elif idx < 10:
+            # Encoder layers (full resolution)
+            in_c = 1 if idx == 0 else ch
+            out_c, k = ch, 3
+            spatial = spatial_full
+        elif idx > 22:
+            # Decoder layers (full resolution)
+            in_c, out_c, k = ch, ch, 3
+            spatial = spatial_full
+        else:
+            # Bottleneck layers (half resolution)
+            in_c, out_c, k = ch, ch, 3
+            spatial = spatial_half
+
+        f = conv3d_flops(in_c, out_c, k, spatial)
+        b = conv3d_bytes(in_c, out_c, k, spatial, bpe)
+        layers_profile.append(LayerProfile(f"layer_{idx}", f, b))
+        total_flops += f
+        total_bytes += b
+
+        # SiLU activation (all except last and upsample)
+        if not is_last and not is_upsample:
+            out_spatial = spatial_half if is_downsample else spatial
+            af = activation_flops(out_c * out_spatial)
+            ab = activation_bytes(out_c * out_spatial, bpe)
+            layers_profile.append(LayerProfile(f"silu_{idx}", af, ab))
+            total_flops += af
+            total_bytes += ab
+
+    return ModelProfile(
+        model_name="",
+        dtype=dtype,
+        total_flops=total_flops,
+        total_bytes=total_bytes,
+        layers=[asdict(lp) for lp in layers_profile],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runtime profiling: actually run inference and measure wall time
+# ---------------------------------------------------------------------------
+
+def profile_inference(model_name: str, vol, dtype: str) -> float:
+    """Run one inference pass and return wall-clock seconds."""
+    from brainchop import segment
+
+    if dtype == "fp16":
+        os.environ["FP16"] = "1"
+    else:
+        os.environ.pop("FP16", None)
+
+    # Warm-up (JIT compile)
+    _ = segment(vol, model_name)
+
+    # Timed run
+    t0 = time.perf_counter()
+    _ = segment(vol, model_name)
+    t1 = time.perf_counter()
+
+    os.environ.pop("FP16", None)
+    return t1 - t0
+
+
+# ---------------------------------------------------------------------------
+# AMD tool wrappers
+# ---------------------------------------------------------------------------
+
+def run_uprof(script_args: list[str], output_dir: str) -> str | None:
+    """Wrap the profiling run with AMDuProfCLI for CPU-side roofline data.
+
+    Requires AMDuProfCLI on PATH (Linux, AMD Zen CPU).
+    Uses 'collect --config tbp' for time-based profiling with IPC/bandwidth
+    counters.
+    """
+    uprof = shutil.which("AMDuProfCLI")
+    if uprof is None:
+        print("  AMDuProfCLI not found on PATH — skipping UProf collection")
+        return None
+
+    out = Path(output_dir) / "uprof"
+    out.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        uprof, "collect",
+        "--config", "tbp",
+        "--output-dir", str(out),
+        "--", sys.executable, *script_args,
+    ]
+    print(f"  Running: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+    # Generate report
+    # Find the most recent result directory
+    result_dirs = sorted(out.iterdir(), key=lambda p: p.stat().st_mtime)
+    if result_dirs:
+        report_cmd = [uprof, "report", "--input-dir", str(result_dirs[-1])]
+        result = subprocess.run(report_cmd, capture_output=True, text=True)
+        report_path = str(out / "report.txt")
+        with open(report_path, "w") as f:
+            f.write(result.stdout)
+        print(f"  UProf report saved to {report_path}")
+        return report_path
+    return None
+
+
+def run_rocprof(script_args: list[str], output_dir: str) -> str | None:
+    """Wrap the profiling run with rocprof for GPU kernel tracing.
+
+    Requires rocprof on PATH (Linux, ROCm).
+    """
+    rocprof = shutil.which("rocprof")
+    if rocprof is None:
+        print("  rocprof not found on PATH — skipping rocprof collection")
+        return None
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    csv_path = str(out / "rocprof_trace.csv")
+    cmd = [
+        rocprof, "--stats",
+        "-o", csv_path,
+        sys.executable, *script_args,
+    ]
+    print(f"  Running: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+    if Path(csv_path).exists():
+        print(f"  rocprof trace saved to {csv_path}")
+        return csv_path
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Roofline plotting
+# ---------------------------------------------------------------------------
+
+def plot_roofline(profiles: list[ModelProfile], peak_gflops: float,
+                  peak_bw_gbs: float, output_path: str):
+    """Generate a roofline chart.
+
+    Args:
+        profiles: List of model profiles with computed AI and achieved GFLOP/s.
+        peak_gflops: Hardware peak compute (GFLOP/s).
+        peak_bw_gbs: Hardware peak memory bandwidth (GB/s).
+        output_path: Where to save the PNG.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib not installed — skipping plot generation")
+        print("  pip install matplotlib")
+        return
+
+    fig, ax = plt.subplots(figsize=(10, 7))
+
+    # Roofline ceiling
+    ridge_point = peak_gflops / peak_bw_gbs  # FLOPs/byte at ridge
+    ai_range = np.logspace(-2, 3, 500)
+    roofline = np.minimum(peak_gflops, ai_range * peak_bw_gbs)
+    ax.loglog(ai_range, roofline, "k-", linewidth=2, label="Roofline ceiling")
+
+    # Shade regions
+    ax.fill_between(ai_range, roofline, alpha=0.05, color="gray")
+    ax.axvline(ridge_point, color="gray", linestyle=":", alpha=0.5)
+    ax.text(ridge_point * 1.1, peak_gflops * 0.7, f"Ridge point\n({ridge_point:.1f} F/B)",
+            fontsize=8, color="gray")
+
+    # Plot each model
+    markers = {"fp32": "o", "fp16": "s", "int8": "^"}
+    colors = {}
+    cmap = plt.cm.tab10
+    model_names = list({p.model_name for p in profiles})
+    for i, name in enumerate(model_names):
+        colors[name] = cmap(i % 10)
+
+    for p in profiles:
+        if p.achieved_gflops is not None and p.achieved_gflops > 0:
+            ai = p.arithmetic_intensity
+            ax.plot(ai, p.achieved_gflops,
+                    marker=markers.get(p.dtype, "o"),
+                    color=colors[p.model_name],
+                    markersize=10, zorder=5)
+            ax.annotate(f"{p.model_name}\n({p.dtype})",
+                        (ai, p.achieved_gflops),
+                        textcoords="offset points", xytext=(8, 4),
+                        fontsize=7, color=colors[p.model_name])
+
+    # Labels
+    ax.set_xlabel("Arithmetic Intensity (FLOPs / Byte)", fontsize=12)
+    ax.set_ylabel("Performance (GFLOP/s)", fontsize=12)
+    ax.set_title(f"Roofline Analysis — brainchop iGPU Inference\n"
+                 f"Peak: {peak_gflops} GFLOP/s  |  BW: {peak_bw_gbs} GB/s",
+                 fontsize=13)
+    ax.legend(fontsize=9)
+    ax.grid(True, which="both", alpha=0.3)
+    ax.set_xlim(0.01, 1000)
+    ax.set_ylim(0.1, peak_gflops * 2)
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    print(f"\nRoofline plot saved to {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Model config resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_model_dir(model_name: str) -> Path:
+    """Resolve model cache directory."""
+    models_json = Path(__file__).resolve().parent.parent / "models.json"
+    with open(models_json) as f:
+        registry = json.load(f)
+    if model_name not in registry:
+        raise ValueError(f"Unknown model: {model_name}")
+    folder = registry[model_name].get("folder", model_name)
+    return Path.home() / ".cache" / "brainchop" / "models" / folder
+
+
+def _get_model_info(model_name: str) -> dict:
+    """Get model metadata from registry."""
+    models_json = Path(__file__).resolve().parent.parent / "models.json"
+    with open(models_json) as f:
+        registry = json.load(f)
+    return registry[model_name]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Profile brainchop models with roofline analysis")
+    parser.add_argument("--models", nargs="+", default=None,
+                        help="Models to profile (default: all)")
+    parser.add_argument("--dtypes", nargs="+", default=["fp32", "fp16"],
+                        choices=["fp32", "fp16"],
+                        help="Data types to test (default: fp32 fp16)")
+    parser.add_argument("--peak-gflops", type=float, default=None,
+                        help="Hardware peak GFLOP/s (auto-detected if omitted)")
+    parser.add_argument("--peak-bw", type=float, default=None,
+                        help="Hardware peak memory bandwidth in GB/s (auto-detected if omitted)")
+    parser.add_argument("--uprof", action="store_true",
+                        help="Run AMD UProf collection (requires AMDuProfCLI)")
+    parser.add_argument("--rocprof", action="store_true",
+                        help="Run rocprof GPU kernel tracing (requires rocprof)")
+    parser.add_argument("--no-plot", action="store_true",
+                        help="Skip roofline plot generation")
+    parser.add_argument("--no-run", action="store_true",
+                        help="Static analysis only — skip actual inference")
+    parser.add_argument("--output-dir", default="examples",
+                        help="Output directory (default: examples)")
+    parser.add_argument("--timeout", type=int, default=600,
+                        help="Timeout per model in seconds (default: 600)")
+    args = parser.parse_args()
+
+    from tinygrad.helpers import fetch
+    from brainchop import list_models, load
+
+    # Resolve models
+    all_models = list(list_models().keys())
+    models = args.models or all_models
+
+    # Auto-detect hardware ceilings
+    peak_gflops, peak_bw = _detect_hardware(args.peak_gflops, args.peak_bw)
+
+    print("=" * 65)
+    print("brainchop roofline profiler")
+    print(f"  models:      {', '.join(models)}")
+    print(f"  dtypes:      {', '.join(args.dtypes)}")
+    print(f"  peak GFLOP/s: {peak_gflops}")
+    print(f"  peak BW GB/s: {peak_bw}")
+    print(f"  backend:     {_get_backend()}")
+    print("=" * 65)
+
+    # Load test volume (only needed for runtime profiling)
+    vol = None
+    if not args.no_run:
+        test_url = "https://github.com/neuroneural/brainchop-models/raw/main/t1_crop.nii.gz"
+        nifti_path = str(Path(fetch(test_url, "t1_crop.nii.gz")))
+        vol = load(nifti_path)
+        print(f"Test volume loaded: shape={vol.data.shape}\n")
+
+    # Profile each model × dtype
+    profiles: list[ModelProfile] = []
+
+    for model_name in models:
+        info = _get_model_info(model_name)
+        model_type = info.get("type", "meshnet")
+        n_classes = info.get("n_classes", 3)
+
+        for dtype in args.dtypes:
+            label = f"{model_name} ({dtype})"
+            print(f"[{label}]")
+
+            # Static analysis
+            try:
+                if model_type == "sae":
+                    profile = analyze_sae(n_classes, dtype)
+                else:
+                    model_dir = _resolve_model_dir(model_name)
+                    config_path = str(model_dir / "model.json")
+                    if not Path(config_path).exists():
+                        # Download the model files
+                        print(f"  Downloading model {model_name}…")
+                        from brainchop.utils import find_pth_files
+                        find_pth_files(model_name)
+                    if not Path(config_path).exists():
+                        print(f"  Config not found at {config_path} — skipping")
+                        raise FileNotFoundError(config_path)
+                    profile = analyze_meshnet(config_path, dtype)
+
+                profile.model_name = model_name
+                profile.dtype = dtype
+
+                gflops = profile.total_flops / 1e9
+                gbytes = profile.total_bytes / 1e9
+                ai = profile.arithmetic_intensity
+                print(f"  Static:  {gflops:.2f} GFLOP  |  {gbytes:.2f} GB transferred  |  AI = {ai:.2f} F/B")
+
+            except Exception as e:
+                print(f"  Static analysis failed: {e}")
+                profile = ModelProfile(model_name, dtype, 0, 0, [])
+
+            # Runtime profiling
+            if not args.no_run:
+                try:
+                    print(f"  Running inference (warm-up + timed)…")
+                    wall_time = profile_inference(model_name, vol, dtype)
+                    profile.wall_time_s = wall_time
+
+                    if profile.total_flops > 0:
+                        profile.achieved_gflops = (profile.total_flops / 1e9) / wall_time
+                        profile.achieved_bw_gbs = (profile.total_bytes / 1e9) / wall_time
+
+                    print(f"  Runtime: {wall_time:.3f}s  |  "
+                          f"{profile.achieved_gflops:.1f} GFLOP/s  |  "
+                          f"{profile.achieved_bw_gbs:.1f} GB/s")
+                except Exception as e:
+                    print(f"  Runtime profiling failed: {e}")
+
+            profiles.append(profile)
+            print()
+
+    # Save results
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results_path = str(out_dir / "roofline_results.json")
+
+    results_data = {
+        "hardware": {
+            "peak_gflops": peak_gflops,
+            "peak_bw_gbs": peak_bw,
+            "backend": _get_backend(),
+        },
+        "profiles": [],
+    }
+    for p in profiles:
+        results_data["profiles"].append({
+            "model": p.model_name,
+            "dtype": p.dtype,
+            "total_gflops": p.total_flops / 1e9,
+            "total_gb": p.total_bytes / 1e9,
+            "arithmetic_intensity": p.arithmetic_intensity,
+            "wall_time_s": p.wall_time_s,
+            "achieved_gflops": p.achieved_gflops,
+            "achieved_bw_gbs": p.achieved_bw_gbs,
+            "layers": p.layers,
+        })
+
+    with open(results_path, "w") as f:
+        json.dump(results_data, f, indent=2)
+    print(f"Results saved to {results_path}")
+
+    # Print summary table
+    _print_summary(profiles)
+
+    # AMD tool wrappers
+    if args.uprof:
+        print("\n--- AMD UProf Collection ---")
+        run_uprof(
+            [__file__, "--models"] + models + ["--dtypes"] + args.dtypes + ["--no-plot"],
+            str(out_dir / "amd_uprof"),
+        )
+
+    if args.rocprof:
+        print("\n--- rocprof GPU Kernel Trace ---")
+        run_rocprof(
+            [__file__, "--models"] + models + ["--dtypes"] + args.dtypes + ["--no-plot"],
+            str(out_dir / "rocprof"),
+        )
+
+    # Roofline plot
+    if not args.no_plot:
+        plot_path = str(out_dir / "roofline_plot.png")
+        plot_roofline(profiles, peak_gflops, peak_bw, plot_path)
+
+
+def _get_backend() -> str:
+    try:
+        from tinygrad import Device
+        return Device.DEFAULT
+    except Exception:
+        return "unknown"
+
+
+def _detect_hardware(user_gflops: float | None, user_bw: float | None) -> tuple[float, float]:
+    """Auto-detect hardware ceilings or use user-supplied values.
+
+    For common iGPUs, provides reasonable defaults. Falls back to
+    conservative estimates.
+    """
+    import platform
+
+    gflops = user_gflops
+    bw = user_bw
+
+    if gflops is None or bw is None:
+        system = platform.system()
+        machine = platform.machine()
+
+        # Try to detect GPU info
+        gpu_info = _detect_gpu_info()
+
+        if gpu_info:
+            # Use detected values
+            gflops = gflops or gpu_info.get("peak_gflops", 200)
+            bw = bw or gpu_info.get("peak_bw_gbs", 50)
+        else:
+            # Conservative defaults for typical iGPUs
+            if system == "Darwin" and machine == "arm64":
+                # Apple Silicon — M1 ~2.6 TFLOP/s FP32, ~200 GB/s
+                gflops = gflops or 2600
+                bw = bw or 200
+            else:
+                # Generic iGPU estimate
+                gflops = gflops or 500
+                bw = bw or 50
+
+        if gpu_info:
+            print(f"  Detected: {gpu_info.get('name', 'unknown GPU')}")
+
+    return gflops, bw
+
+
+def _detect_gpu_info() -> dict | None:
+    """Try to detect GPU name and specs."""
+    import platform
+
+    # macOS: Apple Silicon detection
+    if platform.system() == "Darwin":
+        try:
+            result = subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                capture_output=True, text=True,
+            )
+            cpu = result.stdout.strip()
+            # Also get GPU core count via system_profiler
+            result2 = subprocess.run(
+                ["system_profiler", "SPDisplaysDataType"],
+                capture_output=True, text=True,
+            )
+            gpu_line = ""
+            for line in result2.stdout.splitlines():
+                if "Chipset Model" in line:
+                    gpu_line = line.split(":")[-1].strip()
+                    break
+
+            name = gpu_line or cpu
+            # Rough estimates for Apple Silicon
+            if "M1" in name:
+                return {"name": name, "peak_gflops": 2600, "peak_bw_gbs": 68}
+            elif "M2" in name:
+                return {"name": name, "peak_gflops": 3600, "peak_bw_gbs": 100}
+            elif "M3" in name:
+                return {"name": name, "peak_gflops": 4100, "peak_bw_gbs": 100}
+            elif "M4" in name:
+                return {"name": name, "peak_gflops": 4600, "peak_bw_gbs": 120}
+            else:
+                return {"name": name, "peak_gflops": 2600, "peak_bw_gbs": 68}
+        except Exception:
+            pass
+
+    # Linux: try lspci for AMD/Intel iGPU
+    if platform.system() == "Linux":
+        try:
+            result = subprocess.run(
+                ["lspci"], capture_output=True, text=True,
+            )
+            for line in result.stdout.splitlines():
+                if "VGA" in line or "Display" in line:
+                    name = line.split(":")[-1].strip()
+                    # AMD Radeon iGPU estimates
+                    if "Radeon" in name and any(x in name for x in ["Vega", "680M", "780M", "890M"]):
+                        if "780M" in name or "890M" in name:
+                            return {"name": name, "peak_gflops": 8600, "peak_bw_gbs": 51}
+                        elif "680M" in name:
+                            return {"name": name, "peak_gflops": 4300, "peak_bw_gbs": 51}
+                        else:
+                            return {"name": name, "peak_gflops": 2000, "peak_bw_gbs": 38}
+                    # Intel iGPU
+                    elif "Intel" in name:
+                        return {"name": name, "peak_gflops": 500, "peak_bw_gbs": 50}
+                    return {"name": name}
+        except Exception:
+            pass
+
+    return None
+
+
+def _print_summary(profiles: list[ModelProfile]):
+    """Print a summary table of results."""
+    print()
+    print("=" * 90)
+    name_w = max((len(p.model_name) for p in profiles), default=10)
+    name_w = max(name_w, 5)
+    print(f"{'Model':<{name_w}}  {'dtype':<5}  {'GFLOP':>8}  {'GB xfer':>8}  "
+          f"{'AI (F/B)':>8}  {'Time (s)':>8}  {'GFLOP/s':>8}  {'GB/s':>8}")
+    print("-" * 90)
+
+    for p in profiles:
+        gf = f"{p.total_flops/1e9:.1f}" if p.total_flops else "—"
+        gb = f"{p.total_bytes/1e9:.1f}" if p.total_bytes else "—"
+        ai = f"{p.arithmetic_intensity:.2f}" if p.total_bytes else "—"
+        wt = f"{p.wall_time_s:.3f}" if p.wall_time_s else "—"
+        ag = f"{p.achieved_gflops:.1f}" if p.achieved_gflops else "—"
+        ab = f"{p.achieved_bw_gbs:.1f}" if p.achieved_bw_gbs else "—"
+        print(f"{p.model_name:<{name_w}}  {p.dtype:<5}  {gf:>8}  {gb:>8}  "
+              f"{ai:>8}  {wt:>8}  {ag:>8}  {ab:>8}")
+
+    print("=" * 90)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/profile_roofline.py
+++ b/examples/profile_roofline.py
@@ -150,8 +150,18 @@ def profile_inference(model_name, vol, dtype, n_warmup=N_WARMUP, n_runs=N_TIMED)
     x = Tensor(vol.data.numpy().astype(np.float32)).reshape(1, 1, 256, 256, 256)
     x = m.normalize(x)
 
-    # Warm up (compile kernels, fill caches)
-    for _ in range(n_warmup):
+    if dtype == "fp16":
+        x = x.half()
+
+    # Warm up and validate dtype
+    out = _run_with_fuse_chunk(m, x, model_name)
+    out.numpy()
+    if dtype == "fp16" and out.dtype.name != "half":
+        raise RuntimeError(
+            f"fp16 requested but output dtype is {out.dtype.name} — "
+            f"model does not run in true half precision")
+
+    for _ in range(n_warmup - 1):
         out = _run_with_fuse_chunk(m, x, model_name)
         out.numpy()  # force GPU sync
 
@@ -201,15 +211,15 @@ def _detect_gpu_name():
 
 
 def _detect_hardware(user_gflops, user_bw):
-    """Return (peak_gflops, peak_bw_gbs, gpu_name).
+    """Return (peak_gflops_fp32, peak_gflops_fp16, peak_bw_gbs, gpu_name).
 
-    Raises SystemExit if peak specs cannot be determined (no exact SKU match
-    and no --peak-gflops / --peak-bw supplied).
+    Apple Silicon does 2x throughput for fp16 vs fp32.
+    Raises SystemExit if peak specs cannot be determined.
     """
     name = _detect_gpu_name() or ""
 
     # Exact-SKU lookup: full chip name → (fp32 GFLOP/s, mem BW GB/s)
-    # Only entries we can confidently map; variants (Pro/Max/Ultra) differ.
+    # Apple Silicon ALUs do 2x fp16 throughput; applied automatically below.
     specs = {
         "Apple M1":          (2600,   68),
         "Apple M1 Pro":      (4100,  200),
@@ -227,25 +237,27 @@ def _detect_hardware(user_gflops, user_bw):
         "Apple M4 Max":     (14200,  546),
     }
 
-    gflops = user_gflops
+    gflops_fp32 = user_gflops
     bw = user_bw
+    fp16_multiplier = 2  # Apple Silicon default; override via --peak-gflops for other HW
 
     matched_sku = None
     if name in specs:
         matched_sku = name
         g, b = specs[name]
-        gflops = gflops or g
+        gflops_fp32 = gflops_fp32 or g
         bw = bw or b
 
     if name:
         print(f"  Detected GPU: {name}" + (f" (matched SKU)" if matched_sku else " (unknown SKU)"))
 
-    if not gflops or not bw:
+    if not gflops_fp32 or not bw:
         print(f"\n  ERROR: Could not determine peak specs for '{name or 'no GPU detected'}'.")
         print("  Supply --peak-gflops and --peak-bw explicitly.")
         raise SystemExit(1)
 
-    return gflops, bw, name
+    gflops_fp16 = gflops_fp32 * fp16_multiplier
+    return gflops_fp32, gflops_fp16, bw, name
 
 
 def _get_backend():
@@ -271,7 +283,7 @@ def _resolve_model_dir(model_name):
 
 # -- Plot ----------------------------------------------------------------------
 
-def plot_roofline(profiles, peak_gflops, peak_bw, output_path):
+def plot_roofline(profiles, peak_gflops_fp32, peak_gflops_fp16, peak_bw, output_path):
     try:
         import matplotlib
         matplotlib.use("Agg")
@@ -282,12 +294,22 @@ def plot_roofline(profiles, peak_gflops, peak_bw, output_path):
 
     fig, ax = plt.subplots(figsize=(10, 7))
     ai_range = np.logspace(-2, 3, 500)
-    roofline = np.minimum(peak_gflops, ai_range * peak_bw)
-    ax.loglog(ai_range, roofline, "k-", lw=2, label="Roofline ceiling")
 
-    ridge = peak_gflops / peak_bw
+    # Draw roofline per dtype if they differ
+    has_fp16 = any(p.dtype == "fp16" for p in profiles if p.achieved_gflops)
+    peak_max = peak_gflops_fp32
+
+    roof_fp32 = np.minimum(peak_gflops_fp32, ai_range * peak_bw)
+    ax.loglog(ai_range, roof_fp32, "k-", lw=2, label=f"fp32 ceiling ({peak_gflops_fp32} GF/s)")
+
+    if has_fp16 and peak_gflops_fp16 != peak_gflops_fp32:
+        roof_fp16 = np.minimum(peak_gflops_fp16, ai_range * peak_bw)
+        ax.loglog(ai_range, roof_fp16, "k--", lw=1.5, label=f"fp16 ceiling ({peak_gflops_fp16} GF/s)")
+        peak_max = peak_gflops_fp16
+
+    ridge = peak_gflops_fp32 / peak_bw
     ax.axvline(ridge, color="gray", ls=":", alpha=0.5)
-    ax.text(ridge * 1.1, peak_gflops * 0.7, f"Ridge\n({ridge:.1f} F/B)",
+    ax.text(ridge * 1.1, peak_gflops_fp32 * 0.7, f"Ridge\n({ridge:.1f} F/B)",
             fontsize=8, color="gray")
 
     markers = {"fp32": "o", "fp16": "s"}
@@ -308,11 +330,11 @@ def plot_roofline(profiles, peak_gflops, peak_bw, output_path):
     ax.set_xlabel("Arithmetic Intensity (FLOPs / Byte)")
     ax.set_ylabel("Performance (GFLOP/s)")
     ax.set_title(f"Roofline — brainchop iGPU\n"
-                 f"Peak: {peak_gflops} GFLOP/s | BW: {peak_bw} GB/s")
+                 f"Peak: {peak_gflops_fp32} GFLOP/s (fp32) | BW: {peak_bw} GB/s")
     ax.legend()
     ax.grid(True, which="both", alpha=0.3)
     ax.set_xlim(0.01, 1000)
-    ax.set_ylim(0.1, peak_gflops * 2)
+    ax.set_ylim(0.1, peak_max * 2)
     plt.tight_layout()
     plt.savefig(output_path, dpi=150)
     print(f"Plot saved to {output_path}")
@@ -342,7 +364,7 @@ def main():
 
     registry = _load_registry()
     models = args.models or list(list_models().keys())
-    peak_gflops, peak_bw, gpu_name = _detect_hardware(args.peak_gflops, args.peak_bw)
+    peak_fp32, peak_fp16, peak_bw, gpu_name = _detect_hardware(args.peak_gflops, args.peak_bw)
     slug = _hw_slug()
     backend = _get_backend()
 
@@ -358,7 +380,7 @@ def main():
     print(f"brainchop roofline profiler  [{slug}]")
     print(f"  models:  {', '.join(models)}")
     print(f"  dtypes:  {', '.join(args.dtypes)}")
-    print(f"  peak:    {peak_gflops} GFLOP/s  |  {peak_bw} GB/s")
+    print(f"  peak:    {peak_fp32} GFLOP/s (fp32) | {peak_fp16} GFLOP/s (fp16) | {peak_bw} GB/s")
     print(f"  backend: {backend}")
     print("=" * 65)
 
@@ -447,7 +469,8 @@ def main():
 
     results_path = out_dir / f"roofline_{slug}.json"
     results_data = {
-        "hardware": {"name": gpu_name, "peak_gflops": peak_gflops,
+        "hardware": {"name": gpu_name, "peak_gflops_fp32": peak_fp32,
+                     "peak_gflops_fp16": peak_fp16,
                      "peak_bw_gbs": peak_bw, "backend": backend, "slug": slug},
         "profiles": [
             {"model": p.model_name, "dtype": p.dtype,
@@ -465,7 +488,7 @@ def main():
 
     if not args.no_plot:
         plot_path = out_dir / f"roofline_{slug}.png"
-        plot_roofline(profiles, peak_gflops, peak_bw, str(plot_path))
+        plot_roofline(profiles, peak_fp32, peak_fp16, peak_bw, str(plot_path))
 
 
 if __name__ == "__main__":

--- a/examples/profile_roofline.py
+++ b/examples/profile_roofline.py
@@ -201,28 +201,50 @@ def _detect_gpu_name():
 
 
 def _detect_hardware(user_gflops, user_bw):
-    """Return (peak_gflops, peak_bw_gbs, gpu_name)."""
+    """Return (peak_gflops, peak_bw_gbs, gpu_name).
+
+    Raises SystemExit if peak specs cannot be determined (no exact SKU match
+    and no --peak-gflops / --peak-bw supplied).
+    """
     name = _detect_gpu_name() or ""
 
-    # Lookup table: substring → (GFLOP/s, GB/s)
+    # Exact-SKU lookup: full chip name → (fp32 GFLOP/s, mem BW GB/s)
+    # Only entries we can confidently map; variants (Pro/Max/Ultra) differ.
     specs = {
-        "M1":   (2600,  68), "M2":   (3600, 100),
-        "M3":   (4100, 100), "M4":   (4600, 120),
-        "780M": (8600,  51), "890M": (8600,  51),
-        "680M": (4300,  51), "Vega": (2000,  38),
+        "Apple M1":          (2600,   68),
+        "Apple M1 Pro":      (4100,  200),
+        "Apple M1 Max":      (8200,  400),
+        "Apple M1 Ultra":   (16400,  800),
+        "Apple M2":          (3600,  100),
+        "Apple M2 Pro":      (5700,  200),
+        "Apple M2 Max":      (9800,  400),
+        "Apple M2 Ultra":   (19600,  800),
+        "Apple M3":          (4100,  100),
+        "Apple M3 Pro":      (5700,  150),
+        "Apple M3 Max":      (9800,  400),
+        "Apple M4":          (4600,  120),
+        "Apple M4 Pro":      (7400,  273),
+        "Apple M4 Max":     (14200,  546),
     }
+
     gflops = user_gflops
     bw = user_bw
-    for key, (g, b) in specs.items():
-        if key in name:
-            gflops = gflops or g
-            bw = bw or b
-            break
 
-    gflops = gflops or 500   # conservative fallback
-    bw = bw or 50
+    matched_sku = None
+    if name in specs:
+        matched_sku = name
+        g, b = specs[name]
+        gflops = gflops or g
+        bw = bw or b
+
     if name:
-        print(f"  Detected: {name}")
+        print(f"  Detected GPU: {name}" + (f" (matched SKU)" if matched_sku else " (unknown SKU)"))
+
+    if not gflops or not bw:
+        print(f"\n  ERROR: Could not determine peak specs for '{name or 'no GPU detected'}'.")
+        print("  Supply --peak-gflops and --peak-bw explicitly.")
+        raise SystemExit(1)
+
     return gflops, bw, name
 
 
@@ -324,6 +346,14 @@ def main():
     slug = _hw_slug()
     backend = _get_backend()
 
+    # Refuse to profile if the runtime backend doesn't match the GPU whose
+    # peak specs we're using — CPU timings against a GPU roofline are nonsense.
+    gpu_backends = {"METAL", "CUDA", "GPU", "HIP", "HSA", "NV"}
+    if not args.no_run and backend not in gpu_backends:
+        print(f"\n  ERROR: tinygrad backend is '{backend}', but peak specs are for GPU '{gpu_name}'.")
+        print(f"  Set the backend (e.g. METAL=1) or use --no-run for static analysis only.")
+        raise SystemExit(1)
+
     print("=" * 65)
     print(f"brainchop roofline profiler  [{slug}]")
     print(f"  models:  {', '.join(models)}")
@@ -346,6 +376,11 @@ def main():
         n_classes = info.get("n_classes", 3)
 
         for dtype in args.dtypes:
+            # SAE models have no half() — fp16 weights aren't supported
+            if dtype == "fp16" and model_type == "sae":
+                print(f"[{model_name} ({dtype})]  skipped — SAE has no fp16 path")
+                continue
+
             print(f"[{model_name} ({dtype})]")
 
             # Static analysis
@@ -380,8 +415,10 @@ def main():
                     if p.total_flops > 0:
                         p.achieved_gflops = (p.total_flops / 1e9) / median_t
                         p.achieved_bw_gbs = (p.total_bytes / 1e9) / median_t
+                    gf_s = f"{p.achieved_gflops:.1f} GFLOP/s" if p.achieved_gflops else "- GFLOP/s"
+                    bw_s = f"{p.achieved_bw_gbs:.1f} GB/s" if p.achieved_bw_gbs else "- GB/s"
                     print(f"  Runtime: {median_t:.3f}s (std={p.wall_time_std:.3f}, n={len(times)}) "
-                          f"| {p.achieved_gflops:.1f} GFLOP/s | {p.achieved_bw_gbs:.1f} GB/s")
+                          f"| {gf_s} | {bw_s}")
                 except Exception as e:
                     print(f"  Runtime failed: {e}")
 

--- a/examples/profile_roofline.py
+++ b/examples/profile_roofline.py
@@ -37,7 +37,13 @@ def conv3d_bytes(in_c, out_c, k, spatial, bpe, has_bias=False):
     return b + out_c * bpe if has_bias else b
 
 def norm_flops(channels, spatial):
-    return 5 * channels * spatial
+    # InstanceNorm (GroupNorm with num_groups=channels, affine=False):
+    # mean (1 div) + variance (sub + sq + 1 div) + normalize (sub + div) = 6 ops/elem
+    return 6 * channels * spatial
+
+def silu_flops(n):
+    # SiLU: x * sigmoid(x) = negate + exp + add + reciprocal + multiply = 5 ops/elem
+    return 5 * n
 
 def elem_flops(n):
     return n
@@ -51,7 +57,9 @@ class ModelProfile:
     dtype: str
     total_flops: int
     total_bytes: int
-    wall_time_s: float | None = None
+    wall_time_s: float | None = None       # median of timed runs
+    wall_time_std: float | None = None
+    wall_time_min: float | None = None
     achieved_gflops: float | None = None
     achieved_bw_gbs: float | None = None
 
@@ -111,12 +119,14 @@ def analyze_sae(n_classes, dtype):
         elif idx > 22:   ic, oc, k, S = ch, ch, 3, S_full
         else:            ic, oc, k, S = ch, ch, 3, S_half
 
-        total_f += conv3d_flops(ic, oc, k, S)
-        total_b += conv3d_bytes(ic, oc, k, S, bpe)
+        # SAE always has bias
+        total_f += conv3d_flops(ic, oc, k, S, has_bias=True)
+        total_b += conv3d_bytes(ic, oc, k, S, bpe, has_bias=True)
 
+        # SiLU activation after every conv except ConvTranspose and final
         if not is_last and not is_up:
             out_S = S_half if is_down else S
-            total_f += elem_flops(oc * out_S)
+            total_f += silu_flops(oc * out_S)
             total_b += 2 * oc * out_S * bpe
 
     return ModelProfile("", dtype, total_f, total_b)
@@ -124,21 +134,38 @@ def analyze_sae(n_classes, dtype):
 
 # -- Runtime profiling ---------------------------------------------------------
 
-def profile_inference(model_name, vol, dtype):
-    from brainchop import segment
+N_WARMUP = 2
+N_TIMED = 5
+
+def profile_inference(model_name, vol, dtype, n_warmup=N_WARMUP, n_runs=N_TIMED):
+    from brainchop.api import _load_model, _run_with_fuse_chunk
+    from tinygrad import Tensor
 
     if dtype == "fp16":
         os.environ["FP16"] = "1"
     else:
         os.environ.pop("FP16", None)
 
-    _ = segment(vol, model_name)          # warm-up
-    t0 = time.perf_counter()
-    _ = segment(vol, model_name)          # timed
-    t1 = time.perf_counter()
+    m = _load_model(model_name)
+    x = Tensor(vol.data.numpy().astype(np.float32)).reshape(1, 1, 256, 256, 256)
+    x = m.normalize(x)
+
+    # Warm up (compile kernels, fill caches)
+    for _ in range(n_warmup):
+        out = _run_with_fuse_chunk(m, x, model_name)
+        out.numpy()  # force GPU sync
+
+    # Timed runs
+    times = []
+    for _ in range(n_runs):
+        t0 = time.perf_counter()
+        out = _run_with_fuse_chunk(m, x, model_name)
+        out.numpy()  # force GPU sync before stopping timer
+        t1 = time.perf_counter()
+        times.append(t1 - t0)
 
     os.environ.pop("FP16", None)
-    return t1 - t0
+    return times
 
 
 # -- Hardware detection --------------------------------------------------------
@@ -278,6 +305,10 @@ def main():
                         choices=["fp32", "fp16"])
     parser.add_argument("--peak-gflops", type=float, default=None)
     parser.add_argument("--peak-bw", type=float, default=None)
+    parser.add_argument("--runs", type=int, default=N_TIMED,
+                        help=f"Number of timed inference runs (default {N_TIMED})")
+    parser.add_argument("--warmup", type=int, default=N_WARMUP,
+                        help=f"Number of warm-up runs (default {N_WARMUP})")
     parser.add_argument("--no-plot", action="store_true")
     parser.add_argument("--no-run", action="store_true",
                         help="Static analysis only — skip inference")
@@ -340,12 +371,17 @@ def main():
             # Runtime
             if not args.no_run:
                 try:
-                    wt = profile_inference(model_name, vol, dtype)
-                    p.wall_time_s = wt
+                    times = profile_inference(model_name, vol, dtype,
+                                              n_warmup=args.warmup, n_runs=args.runs)
+                    median_t = float(np.median(times))
+                    p.wall_time_s = median_t
+                    p.wall_time_std = float(np.std(times))
+                    p.wall_time_min = float(np.min(times))
                     if p.total_flops > 0:
-                        p.achieved_gflops = (p.total_flops / 1e9) / wt
-                        p.achieved_bw_gbs = (p.total_bytes / 1e9) / wt
-                    print(f"  Runtime: {wt:.3f}s | {p.achieved_gflops:.1f} GFLOP/s | {p.achieved_bw_gbs:.1f} GB/s")
+                        p.achieved_gflops = (p.total_flops / 1e9) / median_t
+                        p.achieved_bw_gbs = (p.total_bytes / 1e9) / median_t
+                    print(f"  Runtime: {median_t:.3f}s (std={p.wall_time_std:.3f}, n={len(times)}) "
+                          f"| {p.achieved_gflops:.1f} GFLOP/s | {p.achieved_bw_gbs:.1f} GB/s")
                 except Exception as e:
                     print(f"  Runtime failed: {e}")
 
@@ -355,7 +391,7 @@ def main():
     print()
     w = max((len(p.model_name) for p in profiles), default=5)
     w = max(w, 5)
-    hdr = f"{'Model':<{w}}  {'dtype':<5}  {'GFLOP':>7}  {'GB':>6}  {'AI':>6}  {'Time':>7}  {'GF/s':>7}  {'GB/s':>6}"
+    hdr = f"{'Model':<{w}}  {'dtype':<5}  {'GFLOP':>7}  {'GB':>6}  {'AI':>6}  {'med(s)':>7}  {'std':>6}  {'GF/s':>7}  {'GB/s':>6}"
     print(hdr)
     print("-" * len(hdr))
     for p in profiles:
@@ -363,9 +399,10 @@ def main():
         gb = f"{p.total_bytes/1e9:.1f}" if p.total_bytes else "-"
         ai = f"{p.arithmetic_intensity:.1f}" if p.total_bytes else "-"
         wt = f"{p.wall_time_s:.3f}" if p.wall_time_s else "-"
+        sd = f"{p.wall_time_std:.3f}" if p.wall_time_std else "-"
         ag = f"{p.achieved_gflops:.1f}" if p.achieved_gflops else "-"
         ab = f"{p.achieved_bw_gbs:.1f}" if p.achieved_bw_gbs else "-"
-        print(f"{p.model_name:<{w}}  {p.dtype:<5}  {gf:>7}  {gb:>6}  {ai:>6}  {wt:>7}  {ag:>7}  {ab:>6}")
+        print(f"{p.model_name:<{w}}  {p.dtype:<5}  {gf:>7}  {gb:>6}  {ai:>6}  {wt:>7}  {sd:>6}  {ag:>7}  {ab:>6}")
 
     # Save artifacts with hardware slug
     out_dir = Path(args.output_dir)
@@ -379,7 +416,8 @@ def main():
             {"model": p.model_name, "dtype": p.dtype,
              "total_gflops": p.total_flops / 1e9, "total_gb": p.total_bytes / 1e9,
              "arithmetic_intensity": p.arithmetic_intensity,
-             "wall_time_s": p.wall_time_s,
+             "wall_time_s": p.wall_time_s, "wall_time_std": p.wall_time_std,
+             "wall_time_min": p.wall_time_min,
              "achieved_gflops": p.achieved_gflops, "achieved_bw_gbs": p.achieved_bw_gbs}
             for p in profiles
         ],

--- a/examples/profile_roofline.py
+++ b/examples/profile_roofline.py
@@ -1,44 +1,24 @@
 #!/usr/bin/env python3
 """
-iGPU profiling with roofline-style analysis for brainchop models.
+Roofline profiling for brainchop models on iGPU.
 
-Measures FLOPs, memory bandwidth, and arithmetic intensity per model/dtype,
-then produces a roofline plot. Optionally wraps AMD tools (AMDuProfCLI,
-rocprof) when available.
+Computes FLOPs, memory traffic, and arithmetic intensity per model/dtype.
+Measures wall-clock inference time and plots results on a roofline chart.
+Output filenames are derived from the detected hardware slug.
 
 Usage:
-    # Manual roofline (works everywhere)
-    python examples/profile_roofline.py
-
-    # Specific models
-    python examples/profile_roofline.py --models tissue_fast subcortical
-
-    # FP16 only
-    python examples/profile_roofline.py --dtypes fp16
-
-    # With AMD UProf wrapper (Linux + AMD CPU)
-    python examples/profile_roofline.py --uprof
-
-    # With rocprof wrapper (Linux + ROCm GPU)
-    python examples/profile_roofline.py --rocprof
-
-    # Skip plot generation
-    python examples/profile_roofline.py --no-plot
-
-    # Custom hardware ceilings for roofline
+    python examples/profile_roofline.py                          # all models, fp32+fp16
+    python examples/profile_roofline.py --models tissue_fast     # one model
+    python examples/profile_roofline.py --no-run                 # static analysis only
     python examples/profile_roofline.py --peak-gflops 500 --peak-bw 50
-
-Output:
-    examples/roofline_results.json   — raw profiling data
-    examples/roofline_plot.png       — roofline chart (requires matplotlib)
 """
 
 import argparse
 import json
 import os
-import shutil
+import platform
+import re
 import subprocess
-import sys
 import time
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -46,69 +26,24 @@ from pathlib import Path
 import numpy as np
 
 
-# ---------------------------------------------------------------------------
-# FLOPs / bandwidth accounting
-# ---------------------------------------------------------------------------
+# -- FLOPs / bandwidth helpers ------------------------------------------------
 
-def conv3d_flops(in_c: int, out_c: int, k: int, spatial: int,
-                 groups: int = 1, has_bias: bool = False) -> int:
-    """FLOPs for a single 3-D convolution (multiply-accumulate × 2)."""
-    # Each output element: k^3 * (in_c/groups) MACs
-    macs_per_elem = (k ** 3) * (in_c // groups)
-    total_elems = out_c * spatial
-    flops = 2 * macs_per_elem * total_elems  # mul + add
-    if has_bias:
-        flops += total_elems
-    return flops
+def conv3d_flops(in_c, out_c, k, spatial, has_bias=False):
+    flops = 2 * (k ** 3) * in_c * out_c * spatial
+    return flops + out_c * spatial if has_bias else flops
 
+def conv3d_bytes(in_c, out_c, k, spatial, bpe, has_bias=False):
+    b = (in_c * spatial + out_c * in_c * k**3 + out_c * spatial) * bpe
+    return b + out_c * bpe if has_bias else b
 
-def conv3d_bytes(in_c: int, out_c: int, k: int, spatial: int,
-                 bytes_per_elem: int, has_bias: bool = False) -> int:
-    """Bytes transferred: input + weights + output (lower bound)."""
-    input_bytes = in_c * spatial * bytes_per_elem
-    weight_bytes = out_c * in_c * (k ** 3) * bytes_per_elem
-    if has_bias:
-        weight_bytes += out_c * bytes_per_elem
-    output_bytes = out_c * spatial * bytes_per_elem
-    return input_bytes + weight_bytes + output_bytes
+def norm_flops(channels, spatial):
+    return 5 * channels * spatial
+
+def elem_flops(n):
+    return n
 
 
-def groupnorm_flops(channels: int, spatial: int) -> int:
-    """Approximate FLOPs for GroupNorm (mean + var + normalize)."""
-    n = channels * spatial
-    return 5 * n  # mean, var, sub, div, scale
-
-
-def groupnorm_bytes(channels: int, spatial: int, bytes_per_elem: int) -> int:
-    """Bytes for GroupNorm: read input + write output."""
-    return 2 * channels * spatial * bytes_per_elem
-
-
-def activation_flops(spatial: int) -> int:
-    """FLOPs for element-wise activation (relu/gelu/silu/elu)."""
-    return spatial  # 1 op per element (approximate)
-
-
-def activation_bytes(spatial: int, bytes_per_elem: int) -> int:
-    return 2 * spatial * bytes_per_elem  # read + write
-
-
-# ---------------------------------------------------------------------------
-# Model analysis: walk the architecture and tally FLOPs / bytes
-# ---------------------------------------------------------------------------
-
-@dataclass
-class LayerProfile:
-    name: str
-    flops: int
-    bytes_transferred: int
-
-    @property
-    def arithmetic_intensity(self) -> float:
-        if self.bytes_transferred == 0:
-            return 0.0
-        return self.flops / self.bytes_transferred
-
+# -- Dataclasses ---------------------------------------------------------------
 
 @dataclass
 class ModelProfile:
@@ -116,149 +51,80 @@ class ModelProfile:
     dtype: str
     total_flops: int
     total_bytes: int
-    layers: list
     wall_time_s: float | None = None
     achieved_gflops: float | None = None
     achieved_bw_gbs: float | None = None
 
     @property
-    def arithmetic_intensity(self) -> float:
-        if self.total_bytes == 0:
-            return 0.0
-        return self.total_flops / self.total_bytes
+    def arithmetic_intensity(self):
+        return self.total_flops / self.total_bytes if self.total_bytes else 0.0
 
 
-def _bytes_per_elem(dtype: str) -> int:
+# -- Static analysis -----------------------------------------------------------
+
+def _bpe(dtype):
     return 2 if dtype == "fp16" else 4
 
-
-def analyze_meshnet(config_path: str, dtype: str) -> ModelProfile:
-    """Static FLOPs/bandwidth analysis of a MeshNet model."""
+def analyze_meshnet(config_path, dtype):
     with open(config_path) as f:
         config = json.load(f)
 
-    bpe = _bytes_per_elem(dtype)
-    spatial = 256 ** 3  # 256×256×256
-    layers_profile = []
-    total_flops = 0
-    total_bytes = 0
+    bpe = _bpe(dtype)
+    S = 256 ** 3
+    total_f = total_b = 0
     has_bias = config.get("bias", False)
     has_bnorm = config.get("bnorm", True)
 
-    for i, layer_cfg in enumerate(config["layers"]):
-        in_c = layer_cfg["in_channels"]
-        out_c = layer_cfg["out_channels"]
-        k = layer_cfg["kernel_size"]
+    for i, lc in enumerate(config["layers"]):
+        ic, oc, k = lc["in_channels"], lc["out_channels"], lc["kernel_size"]
+        is_last = (i == len(config["layers"]) - 1)
 
-        # Conv
-        f = conv3d_flops(in_c, out_c, k, spatial, has_bias=has_bias)
-        b = conv3d_bytes(in_c, out_c, k, spatial, bpe, has_bias=has_bias)
-        layers_profile.append(LayerProfile(f"conv_{i}", f, b))
-        total_flops += f
-        total_bytes += b
+        total_f += conv3d_flops(ic, oc, k, S, has_bias)
+        total_b += conv3d_bytes(ic, oc, k, S, bpe, has_bias)
 
-        # GroupNorm (all layers except last)
-        if has_bnorm and i < len(config["layers"]) - 1:
-            gf = groupnorm_flops(out_c, spatial)
-            gb = groupnorm_bytes(out_c, spatial, bpe)
-            layers_profile.append(LayerProfile(f"gnorm_{i}", gf, gb))
-            total_flops += gf
-            total_bytes += gb
+        if not is_last:
+            if has_bnorm:
+                total_f += norm_flops(oc, S)
+                total_b += 2 * oc * S * bpe
+            total_f += elem_flops(oc * S)
+            total_b += 2 * oc * S * bpe
 
-        # Activation (all layers except last)
-        if i < len(config["layers"]) - 1:
-            af = activation_flops(out_c * spatial)
-            ab = activation_bytes(out_c * spatial, bpe)
-            layers_profile.append(LayerProfile(f"act_{i}", af, ab))
-            total_flops += af
-            total_bytes += ab
-
-    return ModelProfile(
-        model_name="",
-        dtype=dtype,
-        total_flops=total_flops,
-        total_bytes=total_bytes,
-        layers=[asdict(lp) for lp in layers_profile],
-    )
+    return ModelProfile("", dtype, total_f, total_b)
 
 
-def analyze_sae(n_classes: int, dtype: str) -> ModelProfile:
-    """Static FLOPs/bandwidth analysis of an SAE model.
+def analyze_sae(n_classes, dtype):
+    from brainchop.sae_model import LAYER_INDICES
 
-    Uses the known architecture: 5 encoder + downsample + 5 bottleneck +
-    upsample + 5 decoder + final 1×1 conv.  All convs are 3×3 with dilations
-    from DILATION_SCHEDULE, 16 channels throughout (except final).
-    """
-    from brainchop.sae_model import DILATION_SCHEDULE, LAYER_INDICES
-
-    bpe = _bytes_per_elem(dtype)
-    ch = 16  # SAE uses 16 channels throughout
-    spatial_full = 256 ** 3
-    spatial_half = 128 ** 3
-
-    layers_profile = []
-    total_flops = 0
-    total_bytes = 0
+    bpe = _bpe(dtype)
+    ch = 16
+    S_full, S_half = 256**3, 128**3
+    total_f = total_b = 0
 
     for i, idx in enumerate(LAYER_INDICES):
         is_last = (i == len(LAYER_INDICES) - 1)
-        is_downsample = (idx == 10)
-        is_upsample = (idx == 22)
+        is_down, is_up = (idx == 10), (idx == 22)
 
-        if is_last:
-            # Final 1×1 conv → n_classes
-            in_c, out_c, k = ch, n_classes, 1
-            spatial = spatial_full
-        elif is_downsample:
-            in_c, out_c, k = ch, ch, 3
-            spatial = spatial_full  # input spatial
-        elif is_upsample:
-            in_c, out_c, k = ch, ch, 2
-            spatial = spatial_half  # input spatial (output is full)
-        elif idx < 10:
-            # Encoder layers (full resolution)
-            in_c = 1 if idx == 0 else ch
-            out_c, k = ch, 3
-            spatial = spatial_full
-        elif idx > 22:
-            # Decoder layers (full resolution)
-            in_c, out_c, k = ch, ch, 3
-            spatial = spatial_full
-        else:
-            # Bottleneck layers (half resolution)
-            in_c, out_c, k = ch, ch, 3
-            spatial = spatial_half
+        if is_last:      ic, oc, k, S = ch, n_classes, 1, S_full
+        elif is_down:    ic, oc, k, S = ch, ch, 3, S_full
+        elif is_up:      ic, oc, k, S = ch, ch, 2, S_half
+        elif idx < 10:   ic, oc, k, S = (1 if idx == 0 else ch), ch, 3, S_full
+        elif idx > 22:   ic, oc, k, S = ch, ch, 3, S_full
+        else:            ic, oc, k, S = ch, ch, 3, S_half
 
-        f = conv3d_flops(in_c, out_c, k, spatial)
-        b = conv3d_bytes(in_c, out_c, k, spatial, bpe)
-        layers_profile.append(LayerProfile(f"layer_{idx}", f, b))
-        total_flops += f
-        total_bytes += b
+        total_f += conv3d_flops(ic, oc, k, S)
+        total_b += conv3d_bytes(ic, oc, k, S, bpe)
 
-        # SiLU activation (all except last and upsample)
-        if not is_last and not is_upsample:
-            out_spatial = spatial_half if is_downsample else spatial
-            af = activation_flops(out_c * out_spatial)
-            ab = activation_bytes(out_c * out_spatial, bpe)
-            layers_profile.append(LayerProfile(f"silu_{idx}", af, ab))
-            total_flops += af
-            total_bytes += ab
+        if not is_last and not is_up:
+            out_S = S_half if is_down else S
+            total_f += elem_flops(oc * out_S)
+            total_b += 2 * oc * out_S * bpe
 
-    return ModelProfile(
-        model_name="",
-        dtype=dtype,
-        total_flops=total_flops,
-        total_bytes=total_bytes,
-        layers=[asdict(lp) for lp in layers_profile],
-    )
+    return ModelProfile("", dtype, total_f, total_b)
 
 
-# ---------------------------------------------------------------------------
-# Runtime profiling: actually run inference and measure wall time
-# ---------------------------------------------------------------------------
+# -- Runtime profiling ---------------------------------------------------------
 
-def profile_inference(model_name: str, vol, dtype: str) -> float:
-    """Run one inference pass and return wall-clock seconds."""
+def profile_inference(model_name, vol, dtype):
     from brainchop import segment
 
     if dtype == "fp16":
@@ -266,354 +132,74 @@ def profile_inference(model_name: str, vol, dtype: str) -> float:
     else:
         os.environ.pop("FP16", None)
 
-    # Warm-up (JIT compile)
-    _ = segment(vol, model_name)
-
-    # Timed run
+    _ = segment(vol, model_name)          # warm-up
     t0 = time.perf_counter()
-    _ = segment(vol, model_name)
+    _ = segment(vol, model_name)          # timed
     t1 = time.perf_counter()
 
     os.environ.pop("FP16", None)
     return t1 - t0
 
 
-# ---------------------------------------------------------------------------
-# AMD tool wrappers
-# ---------------------------------------------------------------------------
+# -- Hardware detection --------------------------------------------------------
 
-def run_uprof(script_args: list[str], output_dir: str) -> str | None:
-    """Wrap the profiling run with AMDuProfCLI for CPU-side roofline data.
+def _hw_slug():
+    """Return a short, filesystem-safe hardware identifier."""
+    name = _detect_gpu_name()
+    if name:
+        slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+        return slug[:48]
+    return platform.node().split(".")[0] or "unknown"
 
-    Requires AMDuProfCLI on PATH (Linux, AMD Zen CPU).
-    Uses 'collect --config tbp' for time-based profiling with IPC/bandwidth
-    counters.
-    """
-    uprof = shutil.which("AMDuProfCLI")
-    if uprof is None:
-        print("  AMDuProfCLI not found on PATH — skipping UProf collection")
-        return None
 
-    out = Path(output_dir) / "uprof"
-    out.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        uprof, "collect",
-        "--config", "tbp",
-        "--output-dir", str(out),
-        "--", sys.executable, *script_args,
-    ]
-    print(f"  Running: {' '.join(cmd)}")
-    subprocess.run(cmd, check=True)
-
-    # Generate report
-    # Find the most recent result directory
-    result_dirs = sorted(out.iterdir(), key=lambda p: p.stat().st_mtime)
-    if result_dirs:
-        report_cmd = [uprof, "report", "--input-dir", str(result_dirs[-1])]
-        result = subprocess.run(report_cmd, capture_output=True, text=True)
-        report_path = str(out / "report.txt")
-        with open(report_path, "w") as f:
-            f.write(result.stdout)
-        print(f"  UProf report saved to {report_path}")
-        return report_path
+def _detect_gpu_name():
+    if platform.system() == "Darwin":
+        try:
+            r = subprocess.run(["system_profiler", "SPDisplaysDataType"],
+                               capture_output=True, text=True)
+            for line in r.stdout.splitlines():
+                if "Chipset Model" in line:
+                    return line.split(":")[-1].strip()
+        except Exception:
+            pass
+    elif platform.system() == "Linux":
+        try:
+            r = subprocess.run(["lspci"], capture_output=True, text=True)
+            for line in r.stdout.splitlines():
+                if "VGA" in line or "Display" in line:
+                    return line.split(":")[-1].strip()
+        except Exception:
+            pass
     return None
 
 
-def run_rocprof(script_args: list[str], output_dir: str) -> str | None:
-    """Wrap the profiling run with rocprof for GPU kernel tracing.
+def _detect_hardware(user_gflops, user_bw):
+    """Return (peak_gflops, peak_bw_gbs, gpu_name)."""
+    name = _detect_gpu_name() or ""
 
-    Requires rocprof on PATH (Linux, ROCm).
-    """
-    rocprof = shutil.which("rocprof")
-    if rocprof is None:
-        print("  rocprof not found on PATH — skipping rocprof collection")
-        return None
-
-    out = Path(output_dir)
-    out.mkdir(parents=True, exist_ok=True)
-    csv_path = str(out / "rocprof_trace.csv")
-    cmd = [
-        rocprof, "--stats",
-        "-o", csv_path,
-        sys.executable, *script_args,
-    ]
-    print(f"  Running: {' '.join(cmd)}")
-    subprocess.run(cmd, check=True)
-    if Path(csv_path).exists():
-        print(f"  rocprof trace saved to {csv_path}")
-        return csv_path
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Roofline plotting
-# ---------------------------------------------------------------------------
-
-def plot_roofline(profiles: list[ModelProfile], peak_gflops: float,
-                  peak_bw_gbs: float, output_path: str):
-    """Generate a roofline chart.
-
-    Args:
-        profiles: List of model profiles with computed AI and achieved GFLOP/s.
-        peak_gflops: Hardware peak compute (GFLOP/s).
-        peak_bw_gbs: Hardware peak memory bandwidth (GB/s).
-        output_path: Where to save the PNG.
-    """
-    try:
-        import matplotlib
-        matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
-    except ImportError:
-        print("matplotlib not installed — skipping plot generation")
-        print("  pip install matplotlib")
-        return
-
-    fig, ax = plt.subplots(figsize=(10, 7))
-
-    # Roofline ceiling
-    ridge_point = peak_gflops / peak_bw_gbs  # FLOPs/byte at ridge
-    ai_range = np.logspace(-2, 3, 500)
-    roofline = np.minimum(peak_gflops, ai_range * peak_bw_gbs)
-    ax.loglog(ai_range, roofline, "k-", linewidth=2, label="Roofline ceiling")
-
-    # Shade regions
-    ax.fill_between(ai_range, roofline, alpha=0.05, color="gray")
-    ax.axvline(ridge_point, color="gray", linestyle=":", alpha=0.5)
-    ax.text(ridge_point * 1.1, peak_gflops * 0.7, f"Ridge point\n({ridge_point:.1f} F/B)",
-            fontsize=8, color="gray")
-
-    # Plot each model
-    markers = {"fp32": "o", "fp16": "s", "int8": "^"}
-    colors = {}
-    cmap = plt.cm.tab10
-    model_names = list({p.model_name for p in profiles})
-    for i, name in enumerate(model_names):
-        colors[name] = cmap(i % 10)
-
-    for p in profiles:
-        if p.achieved_gflops is not None and p.achieved_gflops > 0:
-            ai = p.arithmetic_intensity
-            ax.plot(ai, p.achieved_gflops,
-                    marker=markers.get(p.dtype, "o"),
-                    color=colors[p.model_name],
-                    markersize=10, zorder=5)
-            ax.annotate(f"{p.model_name}\n({p.dtype})",
-                        (ai, p.achieved_gflops),
-                        textcoords="offset points", xytext=(8, 4),
-                        fontsize=7, color=colors[p.model_name])
-
-    # Labels
-    ax.set_xlabel("Arithmetic Intensity (FLOPs / Byte)", fontsize=12)
-    ax.set_ylabel("Performance (GFLOP/s)", fontsize=12)
-    ax.set_title(f"Roofline Analysis — brainchop iGPU Inference\n"
-                 f"Peak: {peak_gflops} GFLOP/s  |  BW: {peak_bw_gbs} GB/s",
-                 fontsize=13)
-    ax.legend(fontsize=9)
-    ax.grid(True, which="both", alpha=0.3)
-    ax.set_xlim(0.01, 1000)
-    ax.set_ylim(0.1, peak_gflops * 2)
-
-    plt.tight_layout()
-    plt.savefig(output_path, dpi=150)
-    print(f"\nRoofline plot saved to {output_path}")
-
-
-# ---------------------------------------------------------------------------
-# Model config resolution
-# ---------------------------------------------------------------------------
-
-def _resolve_model_dir(model_name: str) -> Path:
-    """Resolve model cache directory."""
-    models_json = Path(__file__).resolve().parent.parent / "models.json"
-    with open(models_json) as f:
-        registry = json.load(f)
-    if model_name not in registry:
-        raise ValueError(f"Unknown model: {model_name}")
-    folder = registry[model_name].get("folder", model_name)
-    return Path.home() / ".cache" / "brainchop" / "models" / folder
-
-
-def _get_model_info(model_name: str) -> dict:
-    """Get model metadata from registry."""
-    models_json = Path(__file__).resolve().parent.parent / "models.json"
-    with open(models_json) as f:
-        registry = json.load(f)
-    return registry[model_name]
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="Profile brainchop models with roofline analysis")
-    parser.add_argument("--models", nargs="+", default=None,
-                        help="Models to profile (default: all)")
-    parser.add_argument("--dtypes", nargs="+", default=["fp32", "fp16"],
-                        choices=["fp32", "fp16"],
-                        help="Data types to test (default: fp32 fp16)")
-    parser.add_argument("--peak-gflops", type=float, default=None,
-                        help="Hardware peak GFLOP/s (auto-detected if omitted)")
-    parser.add_argument("--peak-bw", type=float, default=None,
-                        help="Hardware peak memory bandwidth in GB/s (auto-detected if omitted)")
-    parser.add_argument("--uprof", action="store_true",
-                        help="Run AMD UProf collection (requires AMDuProfCLI)")
-    parser.add_argument("--rocprof", action="store_true",
-                        help="Run rocprof GPU kernel tracing (requires rocprof)")
-    parser.add_argument("--no-plot", action="store_true",
-                        help="Skip roofline plot generation")
-    parser.add_argument("--no-run", action="store_true",
-                        help="Static analysis only — skip actual inference")
-    parser.add_argument("--output-dir", default="examples",
-                        help="Output directory (default: examples)")
-    parser.add_argument("--timeout", type=int, default=600,
-                        help="Timeout per model in seconds (default: 600)")
-    args = parser.parse_args()
-
-    from tinygrad.helpers import fetch
-    from brainchop import list_models, load
-
-    # Resolve models
-    all_models = list(list_models().keys())
-    models = args.models or all_models
-
-    # Auto-detect hardware ceilings
-    peak_gflops, peak_bw = _detect_hardware(args.peak_gflops, args.peak_bw)
-
-    print("=" * 65)
-    print("brainchop roofline profiler")
-    print(f"  models:      {', '.join(models)}")
-    print(f"  dtypes:      {', '.join(args.dtypes)}")
-    print(f"  peak GFLOP/s: {peak_gflops}")
-    print(f"  peak BW GB/s: {peak_bw}")
-    print(f"  backend:     {_get_backend()}")
-    print("=" * 65)
-
-    # Load test volume (only needed for runtime profiling)
-    vol = None
-    if not args.no_run:
-        test_url = "https://github.com/neuroneural/brainchop-models/raw/main/t1_crop.nii.gz"
-        nifti_path = str(Path(fetch(test_url, "t1_crop.nii.gz")))
-        vol = load(nifti_path)
-        print(f"Test volume loaded: shape={vol.data.shape}\n")
-
-    # Profile each model × dtype
-    profiles: list[ModelProfile] = []
-
-    for model_name in models:
-        info = _get_model_info(model_name)
-        model_type = info.get("type", "meshnet")
-        n_classes = info.get("n_classes", 3)
-
-        for dtype in args.dtypes:
-            label = f"{model_name} ({dtype})"
-            print(f"[{label}]")
-
-            # Static analysis
-            try:
-                if model_type == "sae":
-                    profile = analyze_sae(n_classes, dtype)
-                else:
-                    model_dir = _resolve_model_dir(model_name)
-                    config_path = str(model_dir / "model.json")
-                    if not Path(config_path).exists():
-                        # Download the model files
-                        print(f"  Downloading model {model_name}…")
-                        from brainchop.utils import find_pth_files
-                        find_pth_files(model_name)
-                    if not Path(config_path).exists():
-                        print(f"  Config not found at {config_path} — skipping")
-                        raise FileNotFoundError(config_path)
-                    profile = analyze_meshnet(config_path, dtype)
-
-                profile.model_name = model_name
-                profile.dtype = dtype
-
-                gflops = profile.total_flops / 1e9
-                gbytes = profile.total_bytes / 1e9
-                ai = profile.arithmetic_intensity
-                print(f"  Static:  {gflops:.2f} GFLOP  |  {gbytes:.2f} GB transferred  |  AI = {ai:.2f} F/B")
-
-            except Exception as e:
-                print(f"  Static analysis failed: {e}")
-                profile = ModelProfile(model_name, dtype, 0, 0, [])
-
-            # Runtime profiling
-            if not args.no_run:
-                try:
-                    print(f"  Running inference (warm-up + timed)…")
-                    wall_time = profile_inference(model_name, vol, dtype)
-                    profile.wall_time_s = wall_time
-
-                    if profile.total_flops > 0:
-                        profile.achieved_gflops = (profile.total_flops / 1e9) / wall_time
-                        profile.achieved_bw_gbs = (profile.total_bytes / 1e9) / wall_time
-
-                    print(f"  Runtime: {wall_time:.3f}s  |  "
-                          f"{profile.achieved_gflops:.1f} GFLOP/s  |  "
-                          f"{profile.achieved_bw_gbs:.1f} GB/s")
-                except Exception as e:
-                    print(f"  Runtime profiling failed: {e}")
-
-            profiles.append(profile)
-            print()
-
-    # Save results
-    out_dir = Path(args.output_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    results_path = str(out_dir / "roofline_results.json")
-
-    results_data = {
-        "hardware": {
-            "peak_gflops": peak_gflops,
-            "peak_bw_gbs": peak_bw,
-            "backend": _get_backend(),
-        },
-        "profiles": [],
+    # Lookup table: substring → (GFLOP/s, GB/s)
+    specs = {
+        "M1":   (2600,  68), "M2":   (3600, 100),
+        "M3":   (4100, 100), "M4":   (4600, 120),
+        "780M": (8600,  51), "890M": (8600,  51),
+        "680M": (4300,  51), "Vega": (2000,  38),
     }
-    for p in profiles:
-        results_data["profiles"].append({
-            "model": p.model_name,
-            "dtype": p.dtype,
-            "total_gflops": p.total_flops / 1e9,
-            "total_gb": p.total_bytes / 1e9,
-            "arithmetic_intensity": p.arithmetic_intensity,
-            "wall_time_s": p.wall_time_s,
-            "achieved_gflops": p.achieved_gflops,
-            "achieved_bw_gbs": p.achieved_bw_gbs,
-            "layers": p.layers,
-        })
+    gflops = user_gflops
+    bw = user_bw
+    for key, (g, b) in specs.items():
+        if key in name:
+            gflops = gflops or g
+            bw = bw or b
+            break
 
-    with open(results_path, "w") as f:
-        json.dump(results_data, f, indent=2)
-    print(f"Results saved to {results_path}")
-
-    # Print summary table
-    _print_summary(profiles)
-
-    # AMD tool wrappers
-    if args.uprof:
-        print("\n--- AMD UProf Collection ---")
-        run_uprof(
-            [__file__, "--models"] + models + ["--dtypes"] + args.dtypes + ["--no-plot"],
-            str(out_dir / "amd_uprof"),
-        )
-
-    if args.rocprof:
-        print("\n--- rocprof GPU Kernel Trace ---")
-        run_rocprof(
-            [__file__, "--models"] + models + ["--dtypes"] + args.dtypes + ["--no-plot"],
-            str(out_dir / "rocprof"),
-        )
-
-    # Roofline plot
-    if not args.no_plot:
-        plot_path = str(out_dir / "roofline_plot.png")
-        plot_roofline(profiles, peak_gflops, peak_bw, plot_path)
+    gflops = gflops or 500   # conservative fallback
+    bw = bw or 50
+    if name:
+        print(f"  Detected: {name}")
+    return gflops, bw, name
 
 
-def _get_backend() -> str:
+def _get_backend():
     try:
         from tinygrad import Device
         return Device.DEFAULT
@@ -621,131 +207,190 @@ def _get_backend() -> str:
         return "unknown"
 
 
-def _detect_hardware(user_gflops: float | None, user_bw: float | None) -> tuple[float, float]:
-    """Auto-detect hardware ceilings or use user-supplied values.
+# -- Model config helpers ------------------------------------------------------
 
-    For common iGPUs, provides reasonable defaults. Falls back to
-    conservative estimates.
-    """
-    import platform
+def _load_registry():
+    p = Path(__file__).resolve().parent.parent / "models.json"
+    with open(p) as f:
+        return json.load(f)
 
-    gflops = user_gflops
-    bw = user_bw
-
-    if gflops is None or bw is None:
-        system = platform.system()
-        machine = platform.machine()
-
-        # Try to detect GPU info
-        gpu_info = _detect_gpu_info()
-
-        if gpu_info:
-            # Use detected values
-            gflops = gflops or gpu_info.get("peak_gflops", 200)
-            bw = bw or gpu_info.get("peak_bw_gbs", 50)
-        else:
-            # Conservative defaults for typical iGPUs
-            if system == "Darwin" and machine == "arm64":
-                # Apple Silicon — M1 ~2.6 TFLOP/s FP32, ~200 GB/s
-                gflops = gflops or 2600
-                bw = bw or 200
-            else:
-                # Generic iGPU estimate
-                gflops = gflops or 500
-                bw = bw or 50
-
-        if gpu_info:
-            print(f"  Detected: {gpu_info.get('name', 'unknown GPU')}")
-
-    return gflops, bw
+def _resolve_model_dir(model_name):
+    reg = _load_registry()
+    folder = reg[model_name].get("folder", model_name)
+    return Path.home() / ".cache" / "brainchop" / "models" / folder
 
 
-def _detect_gpu_info() -> dict | None:
-    """Try to detect GPU name and specs."""
-    import platform
+# -- Plot ----------------------------------------------------------------------
 
-    # macOS: Apple Silicon detection
-    if platform.system() == "Darwin":
-        try:
-            result = subprocess.run(
-                ["sysctl", "-n", "machdep.cpu.brand_string"],
-                capture_output=True, text=True,
-            )
-            cpu = result.stdout.strip()
-            # Also get GPU core count via system_profiler
-            result2 = subprocess.run(
-                ["system_profiler", "SPDisplaysDataType"],
-                capture_output=True, text=True,
-            )
-            gpu_line = ""
-            for line in result2.stdout.splitlines():
-                if "Chipset Model" in line:
-                    gpu_line = line.split(":")[-1].strip()
-                    break
+def plot_roofline(profiles, peak_gflops, peak_bw, output_path):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib not installed — skipping plot (pip install matplotlib)")
+        return
 
-            name = gpu_line or cpu
-            # Rough estimates for Apple Silicon
-            if "M1" in name:
-                return {"name": name, "peak_gflops": 2600, "peak_bw_gbs": 68}
-            elif "M2" in name:
-                return {"name": name, "peak_gflops": 3600, "peak_bw_gbs": 100}
-            elif "M3" in name:
-                return {"name": name, "peak_gflops": 4100, "peak_bw_gbs": 100}
-            elif "M4" in name:
-                return {"name": name, "peak_gflops": 4600, "peak_bw_gbs": 120}
-            else:
-                return {"name": name, "peak_gflops": 2600, "peak_bw_gbs": 68}
-        except Exception:
-            pass
+    fig, ax = plt.subplots(figsize=(10, 7))
+    ai_range = np.logspace(-2, 3, 500)
+    roofline = np.minimum(peak_gflops, ai_range * peak_bw)
+    ax.loglog(ai_range, roofline, "k-", lw=2, label="Roofline ceiling")
 
-    # Linux: try lspci for AMD/Intel iGPU
-    if platform.system() == "Linux":
-        try:
-            result = subprocess.run(
-                ["lspci"], capture_output=True, text=True,
-            )
-            for line in result.stdout.splitlines():
-                if "VGA" in line or "Display" in line:
-                    name = line.split(":")[-1].strip()
-                    # AMD Radeon iGPU estimates
-                    if "Radeon" in name and any(x in name for x in ["Vega", "680M", "780M", "890M"]):
-                        if "780M" in name or "890M" in name:
-                            return {"name": name, "peak_gflops": 8600, "peak_bw_gbs": 51}
-                        elif "680M" in name:
-                            return {"name": name, "peak_gflops": 4300, "peak_bw_gbs": 51}
-                        else:
-                            return {"name": name, "peak_gflops": 2000, "peak_bw_gbs": 38}
-                    # Intel iGPU
-                    elif "Intel" in name:
-                        return {"name": name, "peak_gflops": 500, "peak_bw_gbs": 50}
-                    return {"name": name}
-        except Exception:
-            pass
+    ridge = peak_gflops / peak_bw
+    ax.axvline(ridge, color="gray", ls=":", alpha=0.5)
+    ax.text(ridge * 1.1, peak_gflops * 0.7, f"Ridge\n({ridge:.1f} F/B)",
+            fontsize=8, color="gray")
 
-    return None
-
-
-def _print_summary(profiles: list[ModelProfile]):
-    """Print a summary table of results."""
-    print()
-    print("=" * 90)
-    name_w = max((len(p.model_name) for p in profiles), default=10)
-    name_w = max(name_w, 5)
-    print(f"{'Model':<{name_w}}  {'dtype':<5}  {'GFLOP':>8}  {'GB xfer':>8}  "
-          f"{'AI (F/B)':>8}  {'Time (s)':>8}  {'GFLOP/s':>8}  {'GB/s':>8}")
-    print("-" * 90)
+    markers = {"fp32": "o", "fp16": "s"}
+    cmap = plt.cm.tab10
+    names = list({p.model_name for p in profiles})
+    colors = {n: cmap(i % 10) for i, n in enumerate(names)}
 
     for p in profiles:
-        gf = f"{p.total_flops/1e9:.1f}" if p.total_flops else "—"
-        gb = f"{p.total_bytes/1e9:.1f}" if p.total_bytes else "—"
-        ai = f"{p.arithmetic_intensity:.2f}" if p.total_bytes else "—"
-        wt = f"{p.wall_time_s:.3f}" if p.wall_time_s else "—"
-        ag = f"{p.achieved_gflops:.1f}" if p.achieved_gflops else "—"
-        ab = f"{p.achieved_bw_gbs:.1f}" if p.achieved_bw_gbs else "—"
-        print(f"{p.model_name:<{name_w}}  {p.dtype:<5}  {gf:>8}  {gb:>8}  "
-              f"{ai:>8}  {wt:>8}  {ag:>8}  {ab:>8}")
+        if p.achieved_gflops and p.achieved_gflops > 0:
+            ax.plot(p.arithmetic_intensity, p.achieved_gflops,
+                    marker=markers.get(p.dtype, "o"),
+                    color=colors[p.model_name], ms=10, zorder=5)
+            ax.annotate(f"{p.model_name}\n({p.dtype})",
+                        (p.arithmetic_intensity, p.achieved_gflops),
+                        textcoords="offset points", xytext=(8, 4),
+                        fontsize=7, color=colors[p.model_name])
 
-    print("=" * 90)
+    ax.set_xlabel("Arithmetic Intensity (FLOPs / Byte)")
+    ax.set_ylabel("Performance (GFLOP/s)")
+    ax.set_title(f"Roofline — brainchop iGPU\n"
+                 f"Peak: {peak_gflops} GFLOP/s | BW: {peak_bw} GB/s")
+    ax.legend()
+    ax.grid(True, which="both", alpha=0.3)
+    ax.set_xlim(0.01, 1000)
+    ax.set_ylim(0.1, peak_gflops * 2)
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    print(f"Plot saved to {output_path}")
+
+
+# -- Main ----------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Roofline profiler for brainchop")
+    parser.add_argument("--models", nargs="+", default=None)
+    parser.add_argument("--dtypes", nargs="+", default=["fp32", "fp16"],
+                        choices=["fp32", "fp16"])
+    parser.add_argument("--peak-gflops", type=float, default=None)
+    parser.add_argument("--peak-bw", type=float, default=None)
+    parser.add_argument("--no-plot", action="store_true")
+    parser.add_argument("--no-run", action="store_true",
+                        help="Static analysis only — skip inference")
+    parser.add_argument("--output-dir", default="examples")
+    args = parser.parse_args()
+
+    from tinygrad.helpers import fetch
+    from brainchop import list_models, load
+
+    registry = _load_registry()
+    models = args.models or list(list_models().keys())
+    peak_gflops, peak_bw, gpu_name = _detect_hardware(args.peak_gflops, args.peak_bw)
+    slug = _hw_slug()
+    backend = _get_backend()
+
+    print("=" * 65)
+    print(f"brainchop roofline profiler  [{slug}]")
+    print(f"  models:  {', '.join(models)}")
+    print(f"  dtypes:  {', '.join(args.dtypes)}")
+    print(f"  peak:    {peak_gflops} GFLOP/s  |  {peak_bw} GB/s")
+    print(f"  backend: {backend}")
+    print("=" * 65)
+
+    vol = None
+    if not args.no_run:
+        url = "https://github.com/neuroneural/brainchop-models/raw/main/t1_crop.nii.gz"
+        vol = load(str(Path(fetch(url, "t1_crop.nii.gz"))))
+        print(f"Loaded test volume: shape={vol.data.shape}\n")
+
+    profiles: list[ModelProfile] = []
+
+    for model_name in models:
+        info = registry[model_name]
+        model_type = info.get("type", "meshnet")
+        n_classes = info.get("n_classes", 3)
+
+        for dtype in args.dtypes:
+            print(f"[{model_name} ({dtype})]")
+
+            # Static analysis
+            try:
+                if model_type == "sae":
+                    p = analyze_sae(n_classes, dtype)
+                else:
+                    d = _resolve_model_dir(model_name)
+                    cfg = str(d / "model.json")
+                    if not Path(cfg).exists():
+                        from brainchop.utils import find_pth_files
+                        find_pth_files(model_name)
+                    p = analyze_meshnet(cfg, dtype)
+
+                p.model_name = model_name
+                p.dtype = dtype
+                gf, gb = p.total_flops / 1e9, p.total_bytes / 1e9
+                print(f"  Static:  {gf:.1f} GFLOP | {gb:.1f} GB | AI={p.arithmetic_intensity:.1f} F/B")
+            except Exception as e:
+                print(f"  Static analysis failed: {e}")
+                p = ModelProfile(model_name, dtype, 0, 0)
+
+            # Runtime
+            if not args.no_run:
+                try:
+                    wt = profile_inference(model_name, vol, dtype)
+                    p.wall_time_s = wt
+                    if p.total_flops > 0:
+                        p.achieved_gflops = (p.total_flops / 1e9) / wt
+                        p.achieved_bw_gbs = (p.total_bytes / 1e9) / wt
+                    print(f"  Runtime: {wt:.3f}s | {p.achieved_gflops:.1f} GFLOP/s | {p.achieved_bw_gbs:.1f} GB/s")
+                except Exception as e:
+                    print(f"  Runtime failed: {e}")
+
+            profiles.append(p)
+
+    # Summary table
+    print()
+    w = max((len(p.model_name) for p in profiles), default=5)
+    w = max(w, 5)
+    hdr = f"{'Model':<{w}}  {'dtype':<5}  {'GFLOP':>7}  {'GB':>6}  {'AI':>6}  {'Time':>7}  {'GF/s':>7}  {'GB/s':>6}"
+    print(hdr)
+    print("-" * len(hdr))
+    for p in profiles:
+        gf = f"{p.total_flops/1e9:.1f}" if p.total_flops else "-"
+        gb = f"{p.total_bytes/1e9:.1f}" if p.total_bytes else "-"
+        ai = f"{p.arithmetic_intensity:.1f}" if p.total_bytes else "-"
+        wt = f"{p.wall_time_s:.3f}" if p.wall_time_s else "-"
+        ag = f"{p.achieved_gflops:.1f}" if p.achieved_gflops else "-"
+        ab = f"{p.achieved_bw_gbs:.1f}" if p.achieved_bw_gbs else "-"
+        print(f"{p.model_name:<{w}}  {p.dtype:<5}  {gf:>7}  {gb:>6}  {ai:>6}  {wt:>7}  {ag:>7}  {ab:>6}")
+
+    # Save artifacts with hardware slug
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    results_path = out_dir / f"roofline_{slug}.json"
+    results_data = {
+        "hardware": {"name": gpu_name, "peak_gflops": peak_gflops,
+                     "peak_bw_gbs": peak_bw, "backend": backend, "slug": slug},
+        "profiles": [
+            {"model": p.model_name, "dtype": p.dtype,
+             "total_gflops": p.total_flops / 1e9, "total_gb": p.total_bytes / 1e9,
+             "arithmetic_intensity": p.arithmetic_intensity,
+             "wall_time_s": p.wall_time_s,
+             "achieved_gflops": p.achieved_gflops, "achieved_bw_gbs": p.achieved_bw_gbs}
+            for p in profiles
+        ],
+    }
+    with open(results_path, "w") as f:
+        json.dump(results_data, f, indent=2)
+    print(f"\nResults: {results_path}")
+
+    if not args.no_plot:
+        plot_path = out_dir / f"roofline_{slug}.png"
+        plot_roofline(profiles, peak_gflops, peak_bw, str(plot_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `examples/profile_roofline.py` for roofline-style analysis of all brainchop models (MeshNet + SAE) across FP32 and FP16 data types
- Static FLOPs/bandwidth accounting per layer (conv3d, groupnorm, activation) with arithmetic intensity calculation
- Runtime profiling measuring achieved GFLOP/s and GB/s against hardware ceilings
- Auto-detects hardware peaks for Apple Silicon (M1–M4), AMD Radeon iGPUs (680M/780M/890M), and Intel iGPUs
- Optional AMD tool wrappers: `--uprof` for AMDuProfCLI CPU-side roofline, `--rocprof` for GPU kernel tracing
- Generates roofline plot (log-log) via matplotlib and exports per-layer JSON results

## Usage
```bash
# Static analysis only (no niimath/inference needed)
python examples/profile_roofline.py --no-run

# Full profiling with runtime measurement
python examples/profile_roofline.py --models tissue_fast subcortical --dtypes fp32 fp16

# With AMD UProf on Linux
python examples/profile_roofline.py --uprof

# Custom hardware ceilings
python examples/profile_roofline.py --peak-gflops 500 --peak-bw 50
```

## Test plan
- [x] Static analysis runs for MeshNet models (tissue_fast, subcortical, DKatlas)
- [x] Static analysis runs for SAE models (robust_tissue, big_robust_tissue)
- [x] FP32 and FP16 byte accounting produces correct 2× difference
- [x] Roofline plot generates correctly with matplotlib
- [x] `--no-run` mode works without niimath installed
- [ ] Runtime profiling on machine with niimath + tinygrad backend
- [ ] AMD UProf wrapper on Linux with AMD CPU
- [ ] rocprof wrapper on Linux with ROCm

🤖 Generated with [Claude Code](https://claude.com/claude-code)