### PR TITLE
true fp16 WebGPU export; generalize export script

### DIFF
--- a/OPTIMIZATION_NOTES_dkatlas24.md
+++ b/OPTIMIZATION_NOTES_dkatlas24.md
@@ -1,0 +1,135 @@
+# Optimizing the 24ch / 104-class DKatlas MeshNet for browser WebGPU
+
+How the deep, gridding-free DK-atlas model (24 channels, 13 conv layers, affine
+GroupNorm + GELU, full 256³ volume, dilations ramping to 31) went from
+**unusably slow to ~12 s** in the browser, and why. Measurements are on an Apple
+M-series GPU (Dawn → Metal) running the full 256³ volume.
+
+| variant | inference | notes |
+|---|---|---|
+| fp16, no fixes | ~47 s | also **slower than fp32** (see fix 2) |
+| fp16, `--beam 2` | ~16 s | after fixes 1 + 2 |
+| **fp16, `--beam 3`** | **~12 s** | current best |
+| fp32, `--beam 2` | ~22 s | |
+
+The export script is `examples/export_dkatlas24_webgpu.py`. The two model-side
+fixes are in `brainchop/tiny_meshnet.py`. A third fix is browser-side
+(`brainchop-test/main.js`).
+
+## Why this model is different
+
+The other browser models either **crop** to a brain bounding box (smaller
+volume, e.g. the 30-channel atlas models) or have **foldable / no normalization**
+(conv→relu stacks). This one cannot crop — its receptive field (dilations
+1,3,5,7,13,19,31,… RF=255) is matched to the full 256³ cube, and cropping makes
+the large-dilation layers read mostly zero-padding and collapse the output. It
+also has per-channel **affine GroupNorm that can't be folded**. So it runs the
+full volume with real normalization, like the omnimodal skull stripper (mindgrab,
+15ch) rather than the cropped atlas models.
+
+## Fix 1 — backbone was recomputed once per output chunk (5×)
+
+`SequentialConvArgmax._chunked_argmax` computes the final 24→104 classifier conv
+in chunks (FUSE_CHUNK) fused with argmax, so the 104·256³ logits volume is never
+materialized (memory win). With `--chunk 24` and 104 classes that's 5 chunks.
+
+The bug: `export_model()` traces the chunk loop as one lazy graph. Each chunk
+reads `x` (the backbone output), and without a realization boundary the scheduler
+re-traced the **entire 13-layer backbone in all 5 chunk branches**. The exported
+runner therefore recomputed the whole network 5×. (The CLI was fine — eager
+execution realizes `x` on the first chunk and reuses it.)
+
+Evidence: the input conv kernel appeared **5×** in the runner, and the runner had
+**539 compute passes**.
+
+Fix: `x = x.realize()` once before the chunk loop. Peak memory is unchanged (one
+backbone activation + one chunk), but the backbone computes once.
+Result: **539 → 123 passes**, ~5× faster inference and ~5× faster BEAM/export.
+
+## Fix 2 — "fp16" was fake mixed precision (f32 activations)
+
+tinygrad upcasts reduction accumulators to f32 for half inputs
+(`sum_acc_dtype`: `half → least_upper_dtype(half, float32) = float32`). So a conv
+or GroupNorm on f16 data **returns f32**, and nothing cast it back — the dominant
+24·256³ activation lived as **f32 (1.6 GiB)** through the whole stack. The fp16
+export only halved the (tiny) weights while adding ~1500 element-wise f16↔f32
+conversions. On GPUs without 2:1 f16 throughput (Apple Silicon), that made fp16
+**slower than fp32** (47 s vs 22 s).
+
+Fix: in `MeshNet.__call__`, when the model is half precision, cast each layer's
+**output** back to f16. This is numerically safe — the reduction still
+accumulates in f32 (the cast changes only the *stored* result), so there is no
+f16 variance-sum overflow — and the cast folds into the producing kernel's store
+(no extra pass). The 24·256³ activation is now stored as f16 (0.8 GiB), halving
+the dominant memory traffic.
+Result: fp16 dropped **47 s → 16 s** and is now faster than fp32.
+
+Why not accumulate in f16 too (`SUM_DTYPE=float16`)? Summing 16.7M values per
+channel in f16 is broken regardless of arrangement: naive sums overflow f16's
+65504 ceiling and lose precision after ~2k terms; scaling by 1/N first underflows
+~38% of terms to zero; `x²` overflows once activations leave the unit range. The
+f32 accumulator is an in-register upcast and essentially free — the bytes in
+memory are already f16, which is where the cost was.
+
+## Fix 3 — browser device limits (in brainchop-test, not this repo)
+
+`requestDevice()` must opt into the adapter's `maxComputeInvocationsPerWorkgroup`
+(and the other compute-workgroup limits). BEAM emits workgroups up to 1024
+invocations, but the default device limit is 256, so a BEAM-tuned runner fails
+`createComputePipeline` with *"total number of workgroup invocations (512/1024)
+exceeds the maximum allowed (256)"* unless the higher limit is requested.
+
+## Where the time actually goes (profile)
+
+`DEBUG=2` on `FP16=1 WEBGPU=1 brainchop -m DKatlas …`, aggregated by op:
+
+| op | share |
+|---|---|
+| **conv2d** (12× 24→24, 3³, 256³) | **~90%** |
+| GroupNorm reduce + fused GELU | ~6% |
+| argmax (chunked final conv) | ~1% |
+| f16 store casts (fix 2) | ~3% |
+
+Two things this corrected: GroupNorm is *not* the bottleneck (it's cheap
+streaming reductions), and **dilation barely matters** — per-conv times across
+dilations 3…31 vary only ~1.7× (d31 is no worse than d7), because the conv is a
+fused gather (no im2col buffer) and isn't strongly cache-bound. The cost is
+simply twelve full 24→24-channel 3³ convolutions over 256³, running well below
+the GPU's peak (~250 GFLOPS un-tuned), which is why BEAM helps so much.
+
+## Recipe
+
+The export script is general-purpose (any MeshNet); output names default to the
+`--model-dir` basename and are overridable with `--runner-name`/`--web-model-dir`.
+For the DK-atlas entry the runner name must stay `dkatlas24`, so pass it
+explicitly:
+
+```bash
+source ~/venv/torch/bin/activate
+cd brainchop-cli
+IGNORE_BEAM_CACHE=0 python examples/export_dkatlas24_webgpu.py \
+    --model-dir   ../brainchop-models/meshnet/model24chan104cls \
+    --bct         ../brainchop-test \
+    --runner-name dkatlas24 \
+    --chunk 24 --beam 3 --which both
+```
+
+For another model (e.g. `model24chan1t`) just point `--model-dir` at it and omit
+`--runner-name`; it derives `model24chan1t_runner.js` +
+`public/models/model24chan1t/model.safetensors`.
+
+- `--beam 3` is the sweet spot (~12 s vs ~16 s at beam 2). First run is slow
+  (tens of minutes); it caches, so re-runs at the same beam are fast.
+- **Do not** use `WINO=1` — 3D Winograd is much slower here.
+- Sanity checks on the generated fp16 runner:
+  - `grep -c addComputePass …/dkatlas24_runner.js` ≈ 123 (not ~539 → fix 1 regressed)
+  - `grep -c onSubmittedWorkDone …/dkatlas24_runner.js` = 0 (single submit)
+  - the 24·256³ buffer (`data*_402653184`) should be mostly `array<f16>` (fix 2)
+
+## Next lever
+
+Convs are ~90% of runtime, so after BEAM the remaining knob is **working
+resolution** — 256³ is the dominant cost. A lower-resolution pass (e.g. 160³
+then upsample labels) would scale roughly linearly with voxel count, at some
+accuracy cost. Channel count / depth reductions need retraining (conv cost ∝
+Cin·Cout).

--- a/OPTIMIZATION_NOTES_dkatlas24.md
+++ b/OPTIMIZATION_NOTES_dkatlas24.md
@@ -12,7 +12,7 @@ M-series GPU (Dawn → Metal) running the full 256³ volume.
 | **fp16, `--beam 3`** | **~12 s** | current best |
 | fp32, `--beam 2` | ~22 s | |
 
-The export script is `examples/export_dkatlas24_webgpu.py`. The two model-side
+The export script is `examples/export_meshnet_webgpu.py`. The two model-side
 fixes are in `brainchop/tiny_meshnet.py`. A third fix is browser-side
 (`brainchop-test/main.js`).
 
@@ -107,7 +107,7 @@ explicitly:
 ```bash
 source ~/venv/torch/bin/activate
 cd brainchop-cli
-IGNORE_BEAM_CACHE=0 python examples/export_dkatlas24_webgpu.py \
+IGNORE_BEAM_CACHE=0 python examples/export_meshnet_webgpu.py \
     --model-dir   ../brainchop-models/meshnet/model24chan104cls \
     --bct         ../brainchop-test \
     --runner-name dkatlas24 \

--- a/brainchop/tiny_meshnet.py
+++ b/brainchop/tiny_meshnet.py
@@ -1,6 +1,6 @@
 import os
 from tinygrad.tensor import Tensor
-from tinygrad import nn
+from tinygrad import nn, dtypes
 from tinygrad.nn.state import torch_load, safe_load, load_state_dict
 import json
 import numpy as np
@@ -70,6 +70,18 @@ class SequentialConvArgmax:
 
     def _chunked_argmax(self, x: Tensor, chunk_size: int) -> Tensor:
         """Conv + argmax in chunks of chunk_size channels."""
+        # Realize the backbone output ONCE before chunking. x is the (lazy)
+        # output of the full conv stack; each chunk below reads it to compute a
+        # slice of the final 1x1 classifier conv. In eager CLI execution the
+        # first chunk's .realize() already materializes x and later chunks reuse
+        # it, but export_model() captures x as a lazy graph -- without this
+        # boundary every chunk branch re-traces the entire backbone, so the
+        # exported WebGPU/WebGL runner recomputes the whole network once per
+        # chunk (e.g. 104 classes / chunk 24 = 5x the conv passes, 5x inference
+        # and 5x BEAM/export time). Forcing one realization keeps peak memory
+        # identical (one backbone activation + one chunk) while computing the
+        # backbone exactly once.
+        x = x.realize()
         # First chunk
         end = min(chunk_size, self.out_channels)
         logits = self._conv_channels(x, 0, end).realize()
@@ -269,11 +281,29 @@ class MeshNet:
         return qnormalize(x) # TODO: interpret normalization from config file
 
     def __call__(self, x, fuse_chunk=None):
+        # True fp16 activations. When the model is half precision, cast each
+        # layer's OUTPUT back to f16 so the materialized activation buffers are
+        # f16 (24*256^3 = 0.8 GiB) instead of f32 (1.6 GiB). tinygrad upcasts
+        # reduction accumulators to f32 (sum_acc_dtype: half -> float), so the
+        # conv accumulate and the GroupNorm mean/variance still run in f32 -- the
+        # cast only changes the stored result, NOT the accumulation, so there is
+        # no f16 variance-sum overflow. The cast folds into the producing kernel's
+        # store (no extra pass).
+        #
+        # Why this matters: without it, every conv/GroupNorm returns f32 and the
+        # big activation lives as f32 through the whole stack. The "fp16" export
+        # then only halves the (tiny) weights while adding ~1500 element-wise
+        # f16<->f32 conversions, so on GPUs without 2:1 f16 throughput (e.g. Apple
+        # Silicon) it ran SLOWER than fp32. Keeping activations f16 halves the
+        # dominant (bandwidth-bound) GroupNorm traffic -> the intended ~2x speedup.
+        fp16 = isinstance(self.model[0], nn.Conv2d) and self.model[0].weight.dtype == dtypes.float16
         for layer in self.model[:-1]:  # all layers except final conv
             if isinstance(layer, nn.Conv2d):
                 x = chunked_conv(x, layer)
             else:
                 x = layer(x)
+            if fp16:
+                x = x.cast(dtypes.float16)
         assert self.seq_conv_argmax is not None
         return self.seq_conv_argmax(x, chunk_size=fuse_chunk)
 

--- a/examples/export_meshnet_webgpu.py
+++ b/examples/export_meshnet_webgpu.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Export a brainchop MeshNet to optimized WebGPU runners for brainchop-test.
+
+General-purpose: works for any MeshNet checkpoint (the DK-atlas 24ch/104-class
+model is just the worked example). Output naming defaults to the --model-dir
+basename and can be overridden with --runner-name / --web-model-dir, so one
+script serves every model. Produces fp16 and/or fp32 runners and drops them
+straight into a brainchop-test checkout:
+
+    webgpu_runners/<runner>_runner.js      + public/models/<web-model-dir>/model.safetensors      (fp16)
+    webgpu_runners/<runner>_f32_runner.js  + public/models/<web-model-dir>/model_f32.safetensors  (fp32)
+
+e.g. for the DK-atlas model (--runner-name dkatlas24):
+    webgpu_runners/dkatlas24_runner.js     + public/models/model24chan104cls/model.safetensors
+
+brainchop-test selects fp16 vs fp32 at runtime via the model entry's
+`forceFP32` flag (see inference-webgpu.js); its `webgpu_runner` must equal
+--runner-name.
+
+Two optimizations vs a plain `bc.export(...)`:
+
+  * MEMORY: the final 24->104 classifier conv is computed in chunks of
+    --chunk channels (FUSE_CHUNK), fused with the running arg-max. The full
+    104-channel logits volume (104 * 256^3 * 2B = 3.5 GB at fp16) is never
+    materialized; peak buffer stays at one chunk (<= one 24-channel hidden
+    activation, ~768 MiB fp16). This is baked into the exported kernel graph.
+
+  * SPEED: --beam runs tinygrad's BEAM kernel search so each generated WGSL
+    compute shader gets tuned workgroup/local sizes. BEAM times kernels on the
+    real device, so this step needs a working WebGPU (Dawn) backend.
+
+Run on a machine with the torch/tinygrad env AND a working WebGPU device:
+
+    source ~/venv/torch/bin/activate
+    cd brainchop-cli
+    IGNORE_BEAM_CACHE=0 python examples/export_dkatlas24_webgpu.py \
+        --model-dir   ../brainchop-models/meshnet/model24chan104cls \
+        --bct         ../brainchop-test \
+        --runner-name dkatlas24 \
+        --chunk 24 --beam 3 --which both
+
+(--runner-name defaults to the --model-dir basename; pass it explicitly only
+when the runner name must differ from the folder, as for dkatlas24. --bct is
+required. --beam takes precedence over any BEAM= env var.)
+
+Notes
+-----
+* --model-dir must contain model.json + model.pth (the brainchop weights, e.g.
+  produced by tools/convert_catalyst_gn_hdc_deep.py). You can also pass a model
+  NAME registered in brainchop (e.g. "DKatlas") instead of a path.
+* fp32 needs ~2x the device memory of fp16 during export/BEAM. If BEAM OOMs at
+  fp32, drop --beam for the fp32 pass or raise --chunk granularity (lower
+  --chunk value).
+
+Performance history (Apple M-series, full 256^3, browser WebGPU) -- see
+OPTIMIZATION_NOTES_dkatlas24.md for the full write-up:
+
+  fp16, before any fix ........ ~47 s   (and SLOWER than fp32 -- see below)
+  fp16, --beam 2 .............. ~16 s
+  fp16, --beam 3 .............. ~12 s   <- current best
+  fp32, --beam 2 .............. ~22 s
+
+Three fixes were required to get here; the first two live in
+brainchop/tiny_meshnet.py and are essential -- without them this script
+produces a correct but pathologically slow runner:
+
+  1. Backbone recompute (tiny_meshnet.SequentialConvArgmax._chunked_argmax):
+     the lazy backbone output is now realize()d once before the chunk loop.
+     export_model() traces the chunked final conv, and without a realization
+     boundary every chunk re-traced the whole 13-layer backbone -> the runner
+     recomputed the network once PER CHUNK (104/chunk24 = 5x). Fixing it cut
+     the fp16 runner from 539 -> 123 compute passes (5x inference AND ~5x
+     export/BEAM time).
+
+  2. True fp16 activations (tiny_meshnet.MeshNet.__call__): each layer's output
+     is cast back to f16 so the 24*256^3 activation is stored as f16 (0.8 GiB)
+     not f32 (1.6 GiB). tinygrad upcasts reduction accumulators to f32
+     regardless (sum_acc_dtype: half->float), so this is safe (no f16
+     variance-sum overflow) and the cast folds into the producing kernel. Before
+     this, the "fp16" export kept activations in f32 and only halved the (tiny)
+     weights, so it added ~1500 f16<->f32 conversions and ran SLOWER than fp32
+     on GPUs without 2:1 f16 throughput (Apple Silicon).
+
+  3. (browser side, in brainchop-test/main.js, NOT this repo) requestDevice must
+     opt into the adapter's maxComputeInvocationsPerWorkgroup. BEAM emits
+     workgroups up to 1024 invocations; the default device limit is 256, so the
+     BEAM-tuned runner fails ComputePipeline creation without the higher limit.
+
+Tuning notes:
+* --beam 3 is the sweet spot here; the FIRST run is very slow (BEAM benchmarks
+  many variants per kernel at 256^3 -- tens of minutes), then caches in
+  ~/.cache/tinygrad so re-runs at the same beam are fast. Keep IGNORE_BEAM_CACHE=0.
+* Do NOT use WINO=1: 3D Winograd's transform overhead and large intermediates
+  make these convs much slower, not faster.
+* Profile shows the convolutions are ~90% of runtime (GroupNorm ~6%, argmax ~1%)
+  and dilation has only a mild (~1.7x) effect, so kernel tuning (BEAM) is the
+  main lever; the next one is working resolution (256^3 is the cost).
+"""
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+
+class _ChunkedExport:
+    """Wrap a MeshNet so the traced forward chunks the final conv+argmax.
+
+    export_model() calls `.forward(*inputs)` and `get_state_dict()` on this
+    object; delegating to the wrapped model exposes the conv/GroupNorm weights
+    under `m.*` keys (the generated runner references weights by these names, and
+    we save the matching safetensors, so they stay consistent).
+    """
+
+    def __init__(self, model, chunk):
+        self.m = model
+        self.chunk = int(chunk)
+        self.n_classes = model.n_classes
+
+    def forward(self, x):
+        return self.m(x, fuse_chunk=self.chunk)
+
+
+def _export_one(model_dir, name, fp16, chunk, beam, out_dir):
+    # FP16 must be set BEFORE importing/loading so load_meshnet() halves weights.
+    if fp16:
+        os.environ["FP16"] = "1"
+    else:
+        os.environ.pop("FP16", None)
+    os.environ["WEBGPU"] = "1"
+    if beam and beam > 0:
+        os.environ["BEAM"] = str(beam)
+    else:
+        os.environ.pop("BEAM", None)
+
+    import time
+    from brainchop.api import _load_model
+    import brainchop.export_model as _em
+    from brainchop.export_model import export_model
+    from tinygrad import Tensor, Device
+    from tinygrad.nn.state import safe_save
+
+    # Diagnostic: the export traces on the WEBGPU (Dawn) backend. On a headless
+    # CUDA server Dawn often has no Vulkan device and falls back to SwiftShader
+    # (CPU), which is 10-100x slower than the GPU-backed WebGPU your browser uses.
+    # If this is slow, run the export on a machine with GPU-accelerated WebGPU
+    # (e.g. the M1 Mac, where Dawn uses Metal). Device.DEFAULT should be WEBGPU.
+    print(f"[device] tinygrad Device.DEFAULT = {Device.DEFAULT}")
+
+    # CRITICAL for speed: export_model() calls export_model_webgpu() without a
+    # batch_size, so it defaults to 1. With >1 kernel that forces a
+    # queue.submit() + await onSubmittedWorkDone() between EVERY compute pass --
+    # hundreds of CPU<->GPU round-trips that serialize the GPU and make inference
+    # 1-2 orders of magnitude slower. The working runners (mindgrab, model30*)
+    # batch all passes into ONE command buffer / ONE submit. Inject a large
+    # batch_size so num_statements <= batch_size -> single batch -> one submit.
+    if getattr(_em.export_model_webgpu, "_single_batch_patched", None) is None:
+        _orig_webgpu = _em.export_model_webgpu
+
+        def _single_batch_webgpu(*a, **k):
+            k.setdefault("batch_size", 1_000_000)
+            return _orig_webgpu(*a, **k)
+
+        _single_batch_webgpu._single_batch_patched = True
+        _em.export_model_webgpu = _single_batch_webgpu
+
+    m = _load_model(str(model_dir))
+    # Re-bind the fused conv+argmax to the (possibly halved) final conv so the
+    # classifier runs in the same precision as the rest of the network.
+    if hasattr(m, "init_seq_conv_argmax"):
+        m.init_seq_conv_argmax()
+
+    wrapper = _ChunkedExport(m, chunk)
+    # Feed an fp16 dummy input for the fp16 export so tinygrad keeps the whole
+    # activation stack in f16 (real fp16 compute + half memory bandwidth, ~2x on
+    # most GPUs), with f32 only for the GroupNorm reduction accumulators -- exactly
+    # like the working model30chan50cls runner. Feeding an fp32 input (the previous
+    # behavior) left every activation in f32, so only the weights were f16 and there
+    # was no compute speedup. The browser still passes a Float32Array; the runner's
+    # Float16Array.set() converts it.
+    in_dtype = "float16" if fp16 else "float32"
+    dummy = Tensor.randn(1, 1, 256, 256, 256, dtype=in_dtype)
+
+    print(f"[export] {name}: fp16={fp16} chunk={chunk} beam={beam} ...")
+    print("[export] tracing on WEBGPU (runs the 256^3 model twice to capture the JIT)...")
+    _t0 = time.time()
+    prg, in_sizes, out_sizes, state = export_model(wrapper, "webgpu", dummy, model_name=name)
+    print(f"[export] trace+codegen took {time.time() - _t0:.1f}s "
+          f"(if this is minutes, the WEBGPU backend is likely CPU/SwiftShader -- see header notes)")
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    js_path = out_dir / f"{name}.js"
+    st_path = out_dir / f"{name}.safetensors"
+    js_path.write_text(prg)
+    safe_save(state, str(st_path))
+    print(f"[export]   wrote {js_path} ({js_path.stat().st_size} bytes)")
+    print(f"[export]   wrote {st_path} ({st_path.stat().st_size} bytes)")
+    return js_path, st_path
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-dir", required=True,
+                    help="dir with model.json+model.pth, or a registered model name")
+    ap.add_argument("--bct", required=True, help="path to brainchop-test checkout")
+    ap.add_argument("--chunk", type=int, default=24,
+                    help="FUSE_CHUNK: final-conv channels per chunk (<=24 keeps peak at one hidden activation)")
+    ap.add_argument("--beam", type=int, default=0,
+                    help="BEAM kernel search level (0=off; 3 recommended -- best fp16 result here, "
+                         "~12s vs ~16s at beam 2. The FIRST export is very slow at 256^3 (BEAM "
+                         "benchmarks many variants per kernel -- tens of minutes), then caches in "
+                         "~/.cache/tinygrad, so a later re-run with the same --beam is fast. Keep "
+                         "IGNORE_BEAM_CACHE=0.)")
+    ap.add_argument("--which", choices=["fp16", "fp32", "both"], default="both")
+    ap.add_argument("--runner-name", default=None,
+                    help="base name of the emitted runner: <name>_runner.js (+ <name>_f32_runner.js). "
+                         "The brainchop-test model entry's `webgpu_runner` must equal this. "
+                         "Default: basename of --model-dir (e.g. model24chan104cls). For the deployed "
+                         "DK-atlas entry (id 14) pass --runner-name dkatlas24 to keep that name.")
+    ap.add_argument("--web-model-dir", default=None,
+                    help="subfolder under <bct>/public/models where the safetensors are written "
+                         "(usually already holds the tfjs model.json + colormap.json). "
+                         "Default: basename of --model-dir.")
+    ap.add_argument("--staging", default=None,
+                    help="scratch dir for the raw export (default: /tmp/<runner-name>_export)")
+    args = ap.parse_args()
+
+    # Universal: derive output naming from --model-dir unless overridden. Nothing
+    # here is DK-atlas-specific; this exports any brainchop MeshNet to WebGPU.
+    base = Path(args.model_dir).name
+    runner_name = args.runner_name or base
+    web_model_dir = args.web_model_dir or base
+    staging = args.staging or f"/tmp/{runner_name}_export"
+
+    bct = Path(args.bct)
+    runners = bct / "webgpu_runners"
+    models = bct / "public" / "models" / web_model_dir
+    runners.mkdir(parents=True, exist_ok=True)
+    models.mkdir(parents=True, exist_ok=True)
+
+    jobs = []
+    if args.which in ("fp16", "both"):
+        jobs.append((runner_name, True, "model.safetensors"))
+    if args.which in ("fp32", "both"):
+        jobs.append((f"{runner_name}_f32", False, "model_f32.safetensors"))
+
+    for name, fp16, st_name in jobs:
+        js_path, st_path = _export_one(args.model_dir, name, fp16, args.chunk, args.beam, staging)
+        # Runner JS -> webgpu_runners/<name>_runner.js (auto-discovered by import.meta.glob)
+        dst_js = runners / f"{name}_runner.js"
+        shutil.copyfile(js_path, dst_js)
+        # Weights -> public/models/<web_model_dir>/<st_name>
+        dst_st = models / st_name
+        shutil.copyfile(st_path, dst_st)
+        print(f"[place]  {dst_js}")
+        print(f"[place]  {dst_st}\n")
+
+    print(f"Done. Set the brainchop-test model entry's webgpu_runner to '{runner_name}'.")
+    print(f"  forceFP32:false -> {runner_name}_runner.js + model.safetensors (fp16)")
+    print(f"  forceFP32:true  -> {runner_name}_f32_runner.js + model_f32.safetensors (fp32)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/export_meshnet_webgpu.py
+++ b/examples/export_meshnet_webgpu.py
@@ -33,7 +33,7 @@ Run on a machine with the torch/tinygrad env AND a working WebGPU device:
 
     source ~/venv/torch/bin/activate
     cd brainchop-cli
-    IGNORE_BEAM_CACHE=0 python examples/export_dkatlas24_webgpu.py \
+    IGNORE_BEAM_CACHE=0 python examples/export_meshnet_webgpu.py \
         --model-dir   ../brainchop-models/meshnet/model24chan104cls \
         --bct         ../brainchop-test \
         --runner-name dkatlas24 \


### PR DESCRIPTION
Two model-side fixes in tiny_meshnet.py plus a BEAM=3 export recipe bring fp16 browser inference for the deep 24ch/104-class DKatlas MeshNet (full 256^3, affine GroupNorm, no crop) to ~12s (was ~47s, previously slower than fp32).

1. Backbone recompute: realize() the conv-stack output once before the chunked final-conv/argmax loop. export_model() traced the chunk loop as one lazy graph with no realization boundary, so the runner recomputed the whole 13-layer backbone once per chunk (104/chunk24 = 5x). Fix: 539 -> 123 passes.

2. True fp16 activations: cast each layer's output back to f16 so the 24*256^3 activation is stored as f16 (0.8 GiB) not f32 (1.6 GiB). tinygrad keeps reduction accumulators in f32 (sum_acc_dtype), so this is overflow-safe and folds into the producing kernel. Before, "fp16" kept activations in f32 and ran slower than fp32 on GPUs without 2:1 f16 throughput.

Also generalize examples/export_dkatlas24_webgpu.py: output runner/folder names now derive from --model-dir (overridable via --runner-name/--web-model-dir), so one script exports any MeshNet. Previously it hardcoded dkatlas24 / model24chan104cls and would clobber those outputs when run on another model. DK-atlas export now uses --runner-name dkatlas24 (see OPTIMIZATION_NOTES_dkatlas24.md). Recipe: --beam 3 (~12s vs ~16s at beam 2; do NOT use WINO=1). The matching browser-side requestDevice limit change lives in the brainchop-test repo.